### PR TITLE
feat(ranking-engine): implement weighted composite scoring and tier a…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,10 +253,9 @@ precision = 2
 show_missing = true
 
 # Raised progressively as feature branches land:
-#   feat/ranking-engine    -> 60
 #   feat/report-renderer   -> 75
 #   feat/cli               -> 80
-fail_under = 40
+fail_under = 60
 
 exclude_lines = [
     "pragma: no cover",

--- a/src/reveille/domain/ranking.py
+++ b/src/reveille/domain/ranking.py
@@ -5,7 +5,20 @@ on configurable weighted metrics. Rankings are relative to the
 contributor population within a single analysis window -- no absolute
 thresholds are applied.
 
-Tier designations applied by percentile:
+Normalisation is min-max within the population for each metric except
+consistency, which is already bounded to [0.0, 1.0] as a ratio. When
+the population contains only one contributor, all normalised scores
+resolve to 1.0 and the contributor receives the Commander designation
+by definition.
+
+Recency is computed as an exponentially decayed commit frequency. Each
+contributor's commits are binned by calendar week. The most recent week
+in the analysis window receives a weight of 1.0; each prior week is
+discounted by a decay factor of 0.85. This rewards sustained recent
+activity over historical volume while remaining fully reproducible from
+the raw commit timestamps.
+
+Tier designations applied by percentile rank:
     I    Recruit            0th  -- 20th
     II   Operative          21st -- 40th
     III  Specialist         41st -- 60th
@@ -14,23 +27,27 @@ Tier designations applied by percentile:
     VI   Principal          89th -- 95th
     VII  Commander          96th -- 100th
 
-Default metric weights:
-    commit_volume    0.30  -- Raw commit count, normalised within population.
-    lines            0.25  -- Total lines changed, normalised.
-    consistency      0.25  -- Active days divided by total days in window.
-    recency          0.20  -- Exponentially decayed commit frequency,
-                              favouring recent activity over historical volume.
+Default metric weights (must sum to 1.0):
+    commit_volume    0.30
+    lines            0.25
+    consistency      0.25
+    recency          0.20
 """
 
 from __future__ import annotations
 
 import datetime
+from collections import defaultdict
 
 from reveille.config import RankingWeights
-from reveille.domain.models import ContributorStats, RankedContributor
+from reveille.domain.models import Commit, ContributorStats, RankedContributor
 
-# Tier boundaries: (minimum percentile exclusive, tier number, designation).
-# Evaluated top-down; the first matching entry is applied.
+# Recency decay applied per calendar week moving back from the most recent week.
+_RECENCY_DECAY: float = 0.85
+
+# Tier boundaries evaluated top-down. The first entry whose threshold
+# is strictly less than the contributor's percentile is applied.
+# Format: (exclusive lower bound, tier number, designation)
 _TIER_BOUNDARIES: list[tuple[float, int, str]] = [
     (95.0, 7, "Commander"),
     (88.0, 6, "Principal"),
@@ -38,12 +55,13 @@ _TIER_BOUNDARIES: list[tuple[float, int, str]] = [
     (60.0, 4, "Senior Specialist"),
     (40.0, 3, "Specialist"),
     (20.0, 2, "Operative"),
-    (0.0,  1, "Recruit"),
+    (-1.0, 1, "Recruit"),
 ]
 
 
 def rank_contributors(
     contributors: list[ContributorStats],
+    commits: list[Commit],
     weights: RankingWeights,
     window_start: datetime.date,
     window_end: datetime.date,
@@ -53,6 +71,8 @@ def rank_contributors(
     Args:
         contributors: Aggregated stats for each contributor in the analysis
             window. Must contain at least one entry.
+        commits: Raw commit list for the same window, used to compute
+            per-contributor recency scores.
         weights: Configured metric weights. Must sum to 1.0.
         window_start: First date of the analysis window, inclusive.
         window_end: Last date of the analysis window, inclusive.
@@ -63,14 +83,40 @@ def rank_contributors(
 
     Raises:
         ValueError: If contributors is empty.
-
-    Note:
-        Implementation scheduled for feat/ranking-engine.
     """
-    raise NotImplementedError(
-        "rank_contributors is not yet implemented. "
-        "Scheduled for feat/ranking-engine."
+    if not contributors:
+        raise ValueError(
+            "rank_contributors requires at least one contributor. "
+            "Apply min_commits filtering before calling this function."
+        )
+
+    total_days = max((window_end - window_start).days, 1)
+    commit_index = _build_commit_index(commits)
+
+    raw_scores = _compute_raw_scores(
+        contributors, commit_index, total_days, window_end
     )
+    normalised = _normalise_scores(raw_scores)
+    composite = _compute_composite(normalised, weights)
+    percentiles = _compute_percentiles(composite)
+
+    ranked = []
+    for contributor in contributors:
+        email = contributor.email.lower()
+        score = composite[email]
+        percentile = percentiles[email]
+        tier, designation = assign_tier(percentile)
+        ranked.append(
+            RankedContributor(
+                stats=contributor,
+                composite_score=round(score, 6),
+                percentile=round(percentile, 2),
+                tier=tier,
+                tier_designation=designation,
+            )
+        )
+
+    return sorted(ranked, key=lambda r: r.composite_score, reverse=True)
 
 
 def assign_tier(percentile: float) -> tuple[int, str]:
@@ -94,3 +140,179 @@ def assign_tier(percentile: float) -> tuple[int, str]:
         if percentile > threshold:
             return tier, designation
     return 1, "Recruit"
+
+
+# ------------------------------------------------------------------
+# Private computation helpers
+# ------------------------------------------------------------------
+
+def _build_commit_index(commits: list[Commit]) -> dict[str, list[Commit]]:
+    """Group commits by lowercased author email for O(1) lookup.
+
+    Args:
+        commits: Raw commit list for the analysis window.
+
+    Returns:
+        A dict mapping lowercased email to the contributor's commits.
+    """
+    index: dict[str, list[Commit]] = defaultdict(list)
+    for commit in commits:
+        index[commit.author_email.lower()].append(commit)
+    return dict(index)
+
+
+def _compute_raw_scores(
+    contributors: list[ContributorStats],
+    commit_index: dict[str, list[Commit]],
+    total_days: int,
+    window_end: datetime.date,
+) -> dict[str, dict[str, float]]:
+    """Compute the four raw metric values for each contributor.
+
+    Consistency is computed as active_days / total_days and is already
+    normalised to [0.0, 1.0]. The remaining three metrics are raw counts
+    and volumes requiring subsequent min-max normalisation.
+
+    Args:
+        contributors: Contributor stats for the analysis window.
+        commit_index: Commits grouped by lowercased author email.
+        total_days: Total calendar days in the analysis window.
+        window_end: End of the analysis window, used as the recency anchor.
+
+    Returns:
+        A dict mapping lowercased email to a dict of metric name to raw value.
+    """
+    raw: dict[str, dict[str, float]] = {}
+    for contributor in contributors:
+        email = contributor.email.lower()
+        contributor_commits = commit_index.get(email, [])
+        raw[email] = {
+            "commits": float(contributor.commit_count),
+            "lines": float(contributor.lines_changed),
+            "consistency": contributor.active_days / total_days,
+            "recency": _compute_recency_score(contributor_commits, window_end),
+        }
+    return raw
+
+
+def _compute_recency_score(
+    commits: list[Commit],
+    window_end: datetime.date,
+) -> float:
+    """Compute an exponentially decayed commit frequency score.
+
+    Commits are binned by ISO calendar week. The week containing
+    window_end receives a weight of 1.0. Each prior week is multiplied
+    by _RECENCY_DECAY per week of distance. The score is the sum of
+    (commit_count_in_week * week_weight) across all weeks.
+
+    Args:
+        commits: All commits for a single contributor in the analysis window.
+        window_end: The anchor date from which decay is measured.
+
+    Returns:
+        A non-negative float. Zero if the contributor has no commits.
+    """
+    if not commits:
+        return 0.0
+
+    anchor_week = window_end.isocalendar()[:2]  # (year, week)
+    weekly_counts: dict[tuple[int, int], int] = defaultdict(int)
+    for commit in commits:
+        week_key = commit.timestamp.date().isocalendar()[:2]
+        weekly_counts[week_key] += 1
+
+    score = 0.0
+    for (year, week), count in weekly_counts.items():
+        # Compute week distance as approximate days / 7.
+        anchor_date = datetime.date.fromisocalendar(anchor_week[0], anchor_week[1], 1)
+        commit_date = datetime.date.fromisocalendar(year, week, 1)
+        weeks_ago = max((anchor_date - commit_date).days // 7, 0)
+        weight = _RECENCY_DECAY ** weeks_ago
+        score += count * weight
+
+    return score
+
+
+def _normalise_scores(
+    raw: dict[str, dict[str, float]],
+) -> dict[str, dict[str, float]]:
+    """Apply min-max normalisation to commits, lines, and recency metrics.
+
+    Consistency is already in [0.0, 1.0] and is passed through unchanged.
+    When all contributors share an identical value for a metric (max == min),
+    all normalised values for that metric resolve to 1.0.
+
+    Args:
+        raw: Raw metric values keyed by lowercased email.
+
+    Returns:
+        A dict with the same structure where every value is in [0.0, 1.0].
+    """
+    metrics = ["commits", "lines", "recency"]
+    min_max: dict[str, tuple[float, float]] = {}
+    for metric in metrics:
+        values = [raw[email][metric] for email in raw]
+        min_max[metric] = (min(values), max(values))
+
+    normalised: dict[str, dict[str, float]] = {}
+    for email, scores in raw.items():
+        normalised[email] = {"consistency": scores["consistency"]}
+        for metric in metrics:
+            lo, hi = min_max[metric]
+            if hi == lo:
+                normalised[email][metric] = 1.0
+            else:
+                normalised[email][metric] = (scores[metric] - lo) / (hi - lo)
+
+    return normalised
+
+
+def _compute_composite(
+    normalised: dict[str, dict[str, float]],
+    weights: RankingWeights,
+) -> dict[str, float]:
+    """Compute the weighted composite score for each contributor.
+
+    Args:
+        normalised: Normalised metric scores in [0.0, 1.0] per contributor.
+        weights: Configured metric weights.
+
+    Returns:
+        A dict mapping lowercased email to composite score in [0.0, 1.0].
+    """
+    composite: dict[str, float] = {}
+    for email, scores in normalised.items():
+        composite[email] = (
+            scores["commits"] * weights.commits
+            + scores["lines"] * weights.lines
+            + scores["consistency"] * weights.consistency
+            + scores["recency"] * weights.recency
+        )
+    return composite
+
+
+def _compute_percentiles(composite: dict[str, float]) -> dict[str, float]:
+    """Assign a percentile rank to each contributor based on composite score.
+
+    Uses a standard percentile rank formula. Contributors with identical
+    composite scores receive the same percentile. For a population of one,
+    the single contributor receives the 100th percentile.
+
+    Args:
+        composite: Composite scores keyed by lowercased email.
+
+    Returns:
+        A dict mapping lowercased email to percentile in [0.0, 100.0].
+    """
+    emails = list(composite.keys())
+    n = len(emails)
+    if n == 1:
+        return {emails[0]: 100.0}
+
+    sorted_scores = sorted(composite.values())
+    percentiles: dict[str, float] = {}
+    for email, score in composite.items():
+        rank = sorted_scores.index(score)
+        percentiles[email] = round((rank / (n - 1)) * 100.0, 2)
+    return percentiles

--- a/tests/unit/domain/test_ranking.py
+++ b/tests/unit/domain/test_ranking.py
@@ -1,0 +1,368 @@
+"""Unit tests for reveille.domain.ranking.
+
+All tests run in-process with no I/O. The fixture repository used
+in integration tests is not required here -- inputs are constructed
+directly from domain model constructors.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from reveille.config import RankingWeights
+from reveille.domain.models import Commit, ContributorStats, RankedContributor
+from reveille.domain.ranking import (
+    _compute_percentiles,
+    _compute_recency_score,
+    _normalise_scores,
+    assign_tier,
+    rank_contributors,
+)
+
+# ------------------------------------------------------------------
+# Shared fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture()
+def default_weights() -> RankingWeights:
+    """Default RankingWeights with documented production values."""
+    return RankingWeights()
+
+
+@pytest.fixture()
+def window_start() -> datetime.date:
+    return datetime.date(2024, 1, 1)
+
+
+@pytest.fixture()
+def window_end() -> datetime.date:
+    return datetime.date(2024, 3, 31)
+
+
+def _make_stats(
+    email: str,
+    commit_count: int,
+    lines_added: int = 100,
+    lines_deleted: int = 20,
+    active_days: int = 10,
+    first: datetime.date | None = None,
+    last: datetime.date | None = None,
+) -> ContributorStats:
+    """Construct a ContributorStats instance with sensible defaults."""
+    return ContributorStats(
+        name=email.split("@")[0].capitalize(),
+        email=email,
+        commit_count=commit_count,
+        lines_added=lines_added,
+        lines_deleted=lines_deleted,
+        active_days=active_days,
+        first_commit_date=first or datetime.date(2024, 1, 5),
+        last_commit_date=last or datetime.date(2024, 3, 20),
+    )
+
+
+def _make_commit(
+    email: str,
+    date: datetime.date,
+    lines_added: int = 10,
+    lines_deleted: int = 2,
+) -> Commit:
+    """Construct a Commit instance for a given author and date."""
+    return Commit(
+        sha=f"{email[:4]}{date.isoformat()}",
+        author_name=email.split("@")[0].capitalize(),
+        author_email=email,
+        timestamp=datetime.datetime(
+            date.year, date.month, date.day, 12, 0, 0,
+            tzinfo=datetime.UTC,
+        ),
+        lines_added=lines_added,
+        lines_deleted=lines_deleted,
+    )
+
+
+# ------------------------------------------------------------------
+# assign_tier
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestAssignTier:
+    """Tests for the assign_tier function."""
+
+    @pytest.mark.parametrize(
+        "percentile, expected_tier, expected_designation",
+        [
+            (0.0,   1, "Recruit"),
+            (10.0,  1, "Recruit"),
+            (20.0,  1, "Recruit"),
+            (21.0,  2, "Operative"),
+            (40.0,  2, "Operative"),
+            (41.0,  3, "Specialist"),
+            (60.0,  3, "Specialist"),
+            (61.0,  4, "Senior Specialist"),
+            (75.0,  4, "Senior Specialist"),
+            (76.0,  5, "Lead"),
+            (88.0,  5, "Lead"),
+            (89.0,  6, "Principal"),
+            (95.0,  6, "Principal"),
+            (96.0,  7, "Commander"),
+            (100.0, 7, "Commander"),
+        ],
+    )
+    def test_tier_assignment_at_boundary_and_midpoint(
+        self,
+        percentile: float,
+        expected_tier: int,
+        expected_designation: str,
+    ) -> None:
+        tier, designation = assign_tier(percentile)
+        assert tier == expected_tier
+        assert designation == expected_designation
+
+    def test_below_zero_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="percentile must be in"):
+            assign_tier(-0.1)
+
+    def test_above_one_hundred_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="percentile must be in"):
+            assign_tier(100.1)
+
+
+# ------------------------------------------------------------------
+# rank_contributors
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestRankContributors:
+    """Tests for the rank_contributors orchestration function."""
+
+    def test_empty_contributors_raises_value_error(
+        self,
+        default_weights: RankingWeights,
+        window_start: datetime.date,
+        window_end: datetime.date,
+    ) -> None:
+        with pytest.raises(ValueError, match="at least one contributor"):
+            rank_contributors(
+                contributors=[],
+                commits=[],
+                weights=default_weights,
+                window_start=window_start,
+                window_end=window_end,
+            )
+
+    def test_returns_ranked_contributor_for_each_input(
+        self,
+        default_weights: RankingWeights,
+        window_start: datetime.date,
+        window_end: datetime.date,
+    ) -> None:
+        contributors = [
+            _make_stats("alice@example.com", commit_count=20),
+            _make_stats("bob@example.com", commit_count=8),
+        ]
+        commits = [
+            _make_commit("alice@example.com", datetime.date(2024, 3, 1)),
+            _make_commit("bob@example.com", datetime.date(2024, 2, 1)),
+        ]
+        result = rank_contributors(
+            contributors=contributors,
+            commits=commits,
+            weights=default_weights,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        assert len(result) == 2
+        assert all(isinstance(r, RankedContributor) for r in result)
+
+    def test_result_is_sorted_by_composite_score_descending(
+        self,
+        default_weights: RankingWeights,
+        window_start: datetime.date,
+        window_end: datetime.date,
+    ) -> None:
+        contributors = [
+            _make_stats("alice@example.com", commit_count=50, lines_added=3000),
+            _make_stats("bob@example.com", commit_count=5, lines_added=100),
+        ]
+        commits = [
+            _make_commit("alice@example.com", datetime.date(2024, 3, 20)),
+            _make_commit("bob@example.com", datetime.date(2024, 1, 5)),
+        ]
+        result = rank_contributors(
+            contributors=contributors,
+            commits=commits,
+            weights=default_weights,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        scores = [r.composite_score for r in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_single_contributor_receives_commander_designation(
+        self,
+        default_weights: RankingWeights,
+        window_start: datetime.date,
+        window_end: datetime.date,
+    ) -> None:
+        contributors = [_make_stats("solo@example.com", commit_count=10)]
+        commits = [_make_commit("solo@example.com", datetime.date(2024, 2, 1))]
+        result = rank_contributors(
+            contributors=contributors,
+            commits=commits,
+            weights=default_weights,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        assert result[0].tier == 7
+        assert result[0].tier_designation == "Commander"
+
+    def test_composite_score_is_bounded_to_unit_interval(
+        self,
+        default_weights: RankingWeights,
+        window_start: datetime.date,
+        window_end: datetime.date,
+    ) -> None:
+        contributors = [
+            _make_stats("a@example.com", commit_count=100, lines_added=10000),
+            _make_stats("b@example.com", commit_count=1, lines_added=5),
+        ]
+        commits = [
+            _make_commit("a@example.com", datetime.date(2024, 3, 25)),
+            _make_commit("b@example.com", datetime.date(2024, 1, 2)),
+        ]
+        result = rank_contributors(
+            contributors=contributors,
+            commits=commits,
+            weights=default_weights,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        for ranked in result:
+            assert 0.0 <= ranked.composite_score <= 1.0
+
+    def test_percentile_is_bounded_to_zero_to_one_hundred(
+        self,
+        default_weights: RankingWeights,
+        window_start: datetime.date,
+        window_end: datetime.date,
+    ) -> None:
+        contributors = [
+            _make_stats("a@example.com", commit_count=30),
+            _make_stats("b@example.com", commit_count=15),
+            _make_stats("c@example.com", commit_count=5),
+        ]
+        commits = [
+            _make_commit("a@example.com", datetime.date(2024, 3, 1)),
+            _make_commit("b@example.com", datetime.date(2024, 2, 1)),
+            _make_commit("c@example.com", datetime.date(2024, 1, 15)),
+        ]
+        result = rank_contributors(
+            contributors=contributors,
+            commits=commits,
+            weights=default_weights,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        for ranked in result:
+            assert 0.0 <= ranked.percentile <= 100.0
+
+
+# ------------------------------------------------------------------
+# _compute_recency_score
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestComputeRecencyScore:
+    """Tests for the recency scoring helper."""
+
+    def test_empty_commits_returns_zero(self) -> None:
+        score = _compute_recency_score([], datetime.date(2024, 3, 31))
+        assert score == 0.0
+
+    def test_recent_commit_scores_higher_than_older_commit(self) -> None:
+        anchor = datetime.date(2024, 3, 31)
+        recent = [_make_commit("a@x.com", datetime.date(2024, 3, 25))]
+        older = [_make_commit("a@x.com", datetime.date(2024, 1, 5))]
+        assert _compute_recency_score(recent, anchor) > _compute_recency_score(
+            older, anchor
+        )
+
+    def test_score_is_non_negative(self) -> None:
+        anchor = datetime.date(2024, 3, 31)
+        commits = [
+            _make_commit("a@x.com", datetime.date(2024, 2, 10)),
+            _make_commit("a@x.com", datetime.date(2024, 3, 1)),
+        ]
+        assert _compute_recency_score(commits, anchor) >= 0.0
+
+
+# ------------------------------------------------------------------
+# _normalise_scores
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestNormaliseScores:
+    """Tests for the min-max normalisation helper."""
+
+    def test_all_values_identical_normalises_to_one(self) -> None:
+        raw = {
+            "a@x.com": {"commits": 10.0, "lines": 100.0, "consistency": 0.5, "recency": 5.0},
+            "b@x.com": {"commits": 10.0, "lines": 100.0, "consistency": 0.3, "recency": 5.0},
+        }
+        result = _normalise_scores(raw)
+        assert result["a@x.com"]["commits"] == 1.0
+        assert result["b@x.com"]["commits"] == 1.0
+
+    def test_max_contributor_normalises_commits_to_one(self) -> None:
+        raw = {
+            "a@x.com": {"commits": 50.0, "lines": 500.0, "consistency": 0.8, "recency": 10.0},
+            "b@x.com": {"commits": 10.0, "lines": 100.0, "consistency": 0.2, "recency": 2.0},
+        }
+        result = _normalise_scores(raw)
+        assert result["a@x.com"]["commits"] == 1.0
+        assert result["b@x.com"]["commits"] == 0.0
+
+    def test_consistency_passes_through_unchanged(self) -> None:
+        raw = {
+            "a@x.com": {"commits": 20.0, "lines": 200.0, "consistency": 0.65, "recency": 4.0},
+        }
+        result = _normalise_scores(raw)
+        assert result["a@x.com"]["consistency"] == pytest.approx(0.65)
+
+
+# ------------------------------------------------------------------
+# _compute_percentiles
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestComputePercentiles:
+    """Tests for the percentile computation helper."""
+
+    def test_single_contributor_receives_one_hundred(self) -> None:
+        result = _compute_percentiles({"a@x.com": 0.75})
+        assert result["a@x.com"] == 100.0
+
+    def test_lowest_score_receives_zero_percentile(self) -> None:
+        result = _compute_percentiles({
+            "a@x.com": 0.9,
+            "b@x.com": 0.5,
+            "c@x.com": 0.1,
+        })
+        assert result["c@x.com"] == 0.0
+
+    def test_highest_score_receives_one_hundred_percentile(self) -> None:
+        result = _compute_percentiles({
+            "a@x.com": 0.9,
+            "b@x.com": 0.5,
+            "c@x.com": 0.1,
+        })
+        assert result["a@x.com"] == 100.0
+
+    def test_all_percentiles_are_bounded(self) -> None:
+        scores = {f"user{i}@x.com": float(i) for i in range(10)}
+        result = _compute_percentiles(scores)
+        for p in result.values():
+            assert 0.0 <= p <= 100.0


### PR DESCRIPTION
…ssignment

- Implement rank_contributors with min-max normalisation across four metrics
- Implement assign_tier with parametric tier boundary lookup
- Implement recency scoring with exponential weekly decay (factor 0.85)
- Implement _normalise_scores, _compute_composite, _compute_percentiles helpers
- Add unit tests covering all public and private ranking functions
- Parametric tier boundary tests cover all 15 boundary and midpoint cases
- Raise coverage threshold to 60