### PR TITLE
feat(report-renderer): implement Renderer, HTML template, and report …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,9 +253,8 @@ precision = 2
 show_missing = true
 
 # Raised progressively as feature branches land:
-#   feat/report-renderer   -> 75
-#   feat/cli               -> 80
-fail_under = 60
+#   feat/cli -> 80
+fail_under = 75
 
 exclude_lines = [
     "pragma: no cover",

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -3,21 +3,30 @@
 Combines Jinja2 templating with Plotly chart generation to produce
 a single self-contained HTML file. All JavaScript, CSS, and chart
 data are embedded inline. The output requires no internet connection.
+
+Chart generation follows a single-bundle strategy: the Plotly JavaScript
+library is embedded once in the document head, and all chart divs are
+rendered with include_plotlyjs=False to avoid duplication. This keeps
+the output self-contained while minimising redundant payload.
 """
 
 from __future__ import annotations
 
+import datetime
+from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
-from reveille.domain.models import ReportData
+import plotly.graph_objects as go
+import plotly.offline
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from reveille.domain.models import Commit, RankedContributor, ReportData
+from reveille.exceptions import OutputPathError, RenderError
 
 
 class Renderer:
-    """Renders a ReportData instance into a self-contained HTML file.
-
-    Note:
-        Full implementation scheduled for feat/report-renderer.
-    """
+    """Renders a ReportData instance into a self-contained HTML file."""
 
     def __init__(self) -> None:
         """Load the Jinja2 environment and validate the template is present.
@@ -26,10 +35,18 @@ class Renderer:
             RenderError: If the report template cannot be located within
                 the installed package.
         """
-        raise NotImplementedError(
-            "Renderer.__init__ is not yet implemented. "
-            "Scheduled for feat/report-renderer."
-        )
+        try:
+            self._env = Environment(
+                loader=PackageLoader("reveille", "templates"),
+                autoescape=select_autoescape(["html", "j2"]),
+            )
+            self._template = self._env.get_template("report.html.j2")
+        except Exception as exc:
+            raise RenderError(
+                "Failed to load the report template. "
+                "Verify the package was installed correctly and that "
+                "src/reveille/templates/report.html.j2 exists."
+            ) from exc
 
     def render(self, data: ReportData, output_path: Path) -> Path:
         """Render the report and write it to the specified output path.
@@ -46,7 +63,401 @@ class Renderer:
                 the file cannot be written.
             RenderError: If the Jinja2 template raises an error.
         """
-        raise NotImplementedError(
-            "Renderer.render is not yet implemented. "
-            "Scheduled for feat/report-renderer."
+        resolved = output_path.resolve()
+        if not resolved.parent.exists():
+            raise OutputPathError(
+                f"Output directory '{resolved.parent}' does not exist. "
+                "Create the directory before generating a report."
+            )
+
+        try:
+            charts = self._build_charts(data)
+            derived = self._compute_derived_stats(data)
+            plotly_js = plotly.offline.get_plotlyjs()
+            generated_at = data.metadata.generated_at.strftime(
+                "%Y-%m-%d %H:%M UTC"
+            )
+            html = self._template.render(
+                data=data,
+                charts=charts,
+                derived=derived,
+                plotly_js=plotly_js,
+                generated_at=generated_at,
+            )
+        except RenderError:
+            raise
+        except Exception as exc:
+            raise RenderError(f"Template rendering failed: {exc}") from exc
+
+        try:
+            resolved.write_text(html, encoding="utf-8")
+        except OSError as exc:
+            raise OutputPathError(
+                f"Failed to write report to '{resolved}': {exc}"
+            ) from exc
+
+        return resolved
+
+    # ------------------------------------------------------------------
+    # Derived statistics
+    # ------------------------------------------------------------------
+
+    def _compute_derived_stats(self, data: ReportData) -> dict[str, object]:
+        """Compute summary statistics not stored on the domain models.
+
+        Args:
+            data: The complete report dataset.
+
+        Returns:
+            A dict of derived metric names to values for use in the template.
+        """
+        return {
+            "bus_factor": _compute_bus_factor(data.ranked_contributors),
+            "longest_inactive_streak": _compute_longest_inactive_streak(
+                data.commits,
+                data.metadata.analysis_since,
+                data.metadata.analysis_until,
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # Chart builders
+    # ------------------------------------------------------------------
+
+    def _build_charts(self, data: ReportData) -> dict[str, str]:
+        """Build all chart HTML strings for the report.
+
+        Args:
+            data: The complete report dataset.
+
+        Returns:
+            A dict mapping chart name to HTML string (div only, no script).
+        """
+        return {
+            "timeline": _build_timeline_chart(data.commits),
+            "heatmap": _build_heatmap_chart(data.commits),
+            "contributor_commits": _build_contributor_commits_chart(
+                data.ranked_contributors
+            ),
+            "contributor_lines": _build_contributor_lines_chart(
+                data.ranked_contributors
+            ),
+        }
+
+
+# ------------------------------------------------------------------
+# Chart construction functions
+# ------------------------------------------------------------------
+
+def _build_timeline_chart(commits: list[Commit]) -> str:
+    """Build a weekly commit frequency line chart.
+
+    Args:
+        commits: All commits in the analysis window.
+
+    Returns:
+        An HTML string containing a Plotly div with no script tags.
+    """
+    if not commits:
+        return "<p class='chart-empty'>No commit data available.</p>"
+
+    weekly: dict[datetime.date, int] = defaultdict(int)
+    for commit in commits:
+        d = commit.timestamp.date()
+        week_start = d - datetime.timedelta(days=d.weekday())
+        weekly[week_start] += 1
+
+    sorted_weeks = sorted(weekly.keys())
+    counts = [weekly[w] for w in sorted_weeks]
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=sorted_weeks,
+            y=counts,
+            mode="lines",
+            fill="tozeroy",
+            line={"color": "#1e40af", "width": 2},
+            fillcolor="rgba(30, 64, 175, 0.08)",
+            hovertemplate="Week of %{x}<br>Commits: %{y}<extra></extra>",
         )
+    )
+    fig.update_layout(
+        **_base_layout(),
+        xaxis_title="Week",
+        yaxis_title="Commits",
+        height=280,
+    )
+    return _to_html(fig)
+
+
+def _build_heatmap_chart(commits: list[Commit]) -> str:
+    """Build a calendar-style commit activity heatmap.
+
+    Rows represent days of the week (Monday to Sunday).
+    Columns represent calendar weeks across the analysis window.
+
+    Args:
+        commits: All commits in the analysis window.
+
+    Returns:
+        An HTML string containing a Plotly div with no script tags.
+    """
+    if not commits:
+        return "<p class='chart-empty'>No commit data available.</p>"
+
+    earliest = min(c.timestamp.date() for c in commits)
+    base_week = earliest - datetime.timedelta(days=earliest.weekday())
+    cell: dict[tuple[int, int], int] = defaultdict(int)
+    week_indices: set[int] = set()
+
+    for commit in commits:
+        d = commit.timestamp.date()
+        week_start = d - datetime.timedelta(days=d.weekday())
+        week_idx = (week_start - base_week).days // 7
+        day_idx = d.weekday()
+        cell[(week_idx, day_idx)] += 1
+        week_indices.add(week_idx)
+
+    num_weeks = max(week_indices) + 1
+    z = [
+        [cell.get((w, day), 0) for w in range(num_weeks)]
+        for day in range(7)
+    ]
+    week_labels = [
+        (base_week + datetime.timedelta(weeks=w)).isoformat()
+        for w in range(num_weeks)
+    ]
+    day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+    fig = go.Figure(
+        go.Heatmap(
+            z=z,
+            x=week_labels,
+            y=day_labels,
+            colorscale=[
+                [0.0, "#f1f5f9"],
+                [0.001, "#bfdbfe"],
+                [0.35, "#3b82f6"],
+                [1.0, "#1e3a8a"],
+            ],
+            showscale=True,
+            hovertemplate="Week: %{x}<br>Day: %{y}<br>Commits: %{z}<extra></extra>",
+        )
+    )
+    layout = _base_layout()
+    layout["yaxis"] = {"autorange": "reversed", "gridcolor": "#e2e8f0"}
+    fig.update_layout(**layout, height=260)
+    return _to_html(fig)
+
+
+def _build_contributor_commits_chart(ranked: list[RankedContributor]) -> str:
+    """Build a horizontal bar chart of commit counts per contributor.
+
+    Contributors are ordered by rank, with the highest-ranked contributor
+    at the top of the chart.
+
+    Args:
+        ranked: Ranked contributor list sorted by composite score descending.
+
+    Returns:
+        An HTML string containing a Plotly div with no script tags.
+    """
+    if not ranked:
+        return "<p class='chart-empty'>No contributor data available.</p>"
+
+    names = [r.stats.name for r in reversed(ranked)]
+    counts = [r.stats.commit_count for r in reversed(ranked)]
+    tiers = [r.tier_designation for r in reversed(ranked)]
+
+    fig = go.Figure(
+        go.Bar(
+            x=counts,
+            y=names,
+            orientation="h",
+            marker_color="#1e40af",
+            customdata=tiers,
+            hovertemplate="%{y}<br>Commits: %{x}<br>Tier: %{customdata}<extra></extra>",
+            text=[str(c) for c in counts],
+            textposition="outside",
+        )
+    )
+    fig.update_layout(
+        **_base_layout(),
+        xaxis_title="Commits",
+        height=max(280, len(ranked) * 44 + 80),
+    )
+    return _to_html(fig)
+
+
+def _build_contributor_lines_chart(ranked: list[RankedContributor]) -> str:
+    """Build a grouped bar chart of lines added and deleted per contributor.
+
+    Args:
+        ranked: Ranked contributor list sorted by composite score descending.
+
+    Returns:
+        An HTML string containing a Plotly div with no script tags.
+    """
+    if not ranked:
+        return "<p class='chart-empty'>No contributor data available.</p>"
+
+    names = [r.stats.name for r in ranked]
+    added = [r.stats.lines_added for r in ranked]
+    deleted = [r.stats.lines_deleted for r in ranked]
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            name="Lines Added",
+            x=names,
+            y=added,
+            marker_color="#059669",
+            hovertemplate="%{x}<br>Added: %{y:,}<extra></extra>",
+        )
+    )
+    fig.add_trace(
+        go.Bar(
+            name="Lines Deleted",
+            x=names,
+            y=deleted,
+            marker_color="#dc2626",
+            hovertemplate="%{x}<br>Deleted: %{y:,}<extra></extra>",
+        )
+    )
+    layout = _base_layout()
+    layout["showlegend"] = True
+    fig.update_layout(
+        **layout,
+        barmode="group",
+        yaxis_title="Lines",
+        legend={"orientation": "h", "y": 1.12, "x": 0},
+        height=340,
+    )
+    return _to_html(fig)
+
+
+# ------------------------------------------------------------------
+# Derived metric helpers
+# ------------------------------------------------------------------
+
+def _compute_bus_factor(ranked: list[RankedContributor]) -> int:
+    """Compute the bus factor for the contributor population.
+
+    The bus factor is the minimum number of contributors whose combined
+    commit volume accounts for at least 50% of total commits. A lower
+    value indicates higher concentration risk.
+
+    Args:
+        ranked: Ranked contributor list.
+
+    Returns:
+        An integer in the range [1, len(ranked)].
+    """
+    if not ranked:
+        return 0
+    total = sum(r.stats.commit_count for r in ranked)
+    if total == 0:
+        return 0
+    threshold = total * 0.5
+    sorted_by_commits = sorted(
+        ranked, key=lambda r: r.stats.commit_count, reverse=True
+    )
+    cumulative = 0
+    for i, contributor in enumerate(sorted_by_commits, start=1):
+        cumulative += contributor.stats.commit_count
+        if cumulative >= threshold:
+            return i
+    return len(ranked)
+
+
+def _compute_longest_inactive_streak(
+    commits: list[Commit],
+    window_start: datetime.date,
+    window_end: datetime.date,
+) -> int:
+    """Compute the longest consecutive inactive period in days.
+
+    An inactive day is a calendar day within the analysis window on
+    which no commits were recorded. The streak is the maximum number
+    of consecutive such days.
+
+    Args:
+        commits: All commits in the analysis window.
+        window_start: Start of the analysis window.
+        window_end: End of the analysis window.
+
+    Returns:
+        The longest inactive streak in days. Zero if every day had a commit.
+    """
+    if not commits:
+        return (window_end - window_start).days
+
+    active_dates = {c.timestamp.date() for c in commits}
+    longest = 0
+    streak = 0
+    current = window_start
+    while current <= window_end:
+        if current not in active_dates:
+            streak += 1
+            longest = max(longest, streak)
+        else:
+            streak = 0
+        current += datetime.timedelta(days=1)
+    return longest
+
+
+# ------------------------------------------------------------------
+# Layout helpers
+# ------------------------------------------------------------------
+
+def _base_layout() -> dict[str, Any]:
+    """Return shared Plotly layout configuration for all charts.
+
+    Enforces a consistent professional aesthetic: system font stack,
+    white background, minimal gridlines, no Plotly logo or branding.
+
+    Returns:
+        A dict of Plotly layout keyword arguments.
+    """
+    return {
+        "paper_bgcolor": "white",
+        "plot_bgcolor": "#f8fafc",
+        "font": {
+            "family": (
+                "-apple-system, BlinkMacSystemFont, 'Segoe UI', "
+                "Roboto, 'Helvetica Neue', Arial, sans-serif"
+            ),
+            "color": "#0f172a",
+            "size": 12,
+        },
+        "margin": {"l": 60, "r": 30, "t": 20, "b": 50},
+        "xaxis": {"gridcolor": "#e2e8f0", "linecolor": "#cbd5e1"},
+        "yaxis": {"gridcolor": "#e2e8f0", "linecolor": "#cbd5e1"},
+        "showlegend": False,
+        "modebar": {"remove": ["logo"]},
+    }
+
+
+def _to_html(fig: go.Figure) -> str:
+    """Serialise a Plotly figure to an HTML div string.
+
+    The Plotly JS bundle is excluded because it is embedded once in the
+    document head by the Jinja2 template. The div is configured as
+    responsive to adapt to its container width.
+
+    Args:
+        fig: A fully configured Plotly Figure instance.
+
+    Returns:
+        An HTML string containing only the chart div element.
+    """
+    return fig.to_html(  # type: ignore[no-any-return]
+        full_html=False,
+        include_plotlyjs=False,
+        config={
+            "responsive": True,
+            "displayModeBar": True,
+            "displaylogo": False,
+        },
+    )

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -1,21 +1,30 @@
 """Application service for report generation.
 
 Orchestrates the full report generation pipeline:
-    1. Validate the repository path and analysis window.
-    2. Read Git log data via the git reader adapter.
-    3. Pass contributor stats to the ranking engine.
-    4. Pass ranked data to the renderer adapter.
-    5. Return the path of the written HTML file.
+    1. Validate the repository path.
+    2. Read Git log data via the GitReader adapter.
+    3. Derive the analysis window boundaries.
+    4. Aggregate contributor statistics.
+    5. Rank contributors using the ranking engine.
+    6. Assemble the ReportData object.
+    7. Render the HTML output via the Renderer adapter.
+    8. Return the absolute path of the written file.
 
-This layer depends on domain models and adapter interfaces.
-It has no direct knowledge of GitPython, Jinja2, Plotly, or Typer.
+This layer has no direct knowledge of GitPython, Jinja2, Plotly,
+or Typer. All external concerns are delegated to adapters.
 """
 
 from __future__ import annotations
 
+import datetime
+from dataclasses import replace
 from pathlib import Path
 
+from reveille.adapters.git_reader import GitReader
+from reveille.adapters.renderer import Renderer
 from reveille.config import ReportConfig
+from reveille.domain.models import RankedContributor, ReportData
+from reveille.domain.ranking import rank_contributors
 
 
 def generate_report(config: ReportConfig) -> Path:
@@ -32,11 +41,66 @@ def generate_report(config: ReportConfig) -> Path:
         EmptyRepositoryError: If no commits exist within the analysis window.
         OutputPathError: If the output file cannot be written.
         RenderError: If the HTML template fails to render.
-
-    Note:
-        Full orchestration implementation scheduled for feat/report-renderer.
     """
-    raise NotImplementedError(
-        "generate_report is not yet implemented. "
-        "Scheduled for feat/report-renderer."
+    reader = GitReader(config.repo_path)
+
+    commits = reader.read_commits(
+        branch=config.branch,
+        since=config.since,
+        until=config.until,
+        exclude_authors=config.exclude_authors,
     )
+
+    window_start = (
+        config.since
+        if config.since is not None
+        else min(c.timestamp.date() for c in commits)
+    )
+    window_end = config.until or datetime.date.today()
+
+    contributor_stats = reader.aggregate_contributor_stats(
+        commits=commits,
+        min_commits=config.min_commits,
+        window_start=window_start,
+        window_end=window_end,
+    )
+
+    ranked_contributors: list[RankedContributor]
+    if config.ranking_enabled and contributor_stats:
+        ranked_contributors = rank_contributors(
+            contributors=contributor_stats,
+            commits=commits,
+            weights=config.ranking_weights,
+            window_start=window_start,
+            window_end=window_end,
+        )
+    else:
+        ranked_contributors = [
+            RankedContributor(
+                stats=s,
+                composite_score=0.0,
+                percentile=0.0,
+                tier=0,
+                tier_designation="--",
+            )
+            for s in contributor_stats
+        ]
+
+    metadata = reader.read_metadata(
+        total_commits=len(commits),
+        unique_contributors=len(contributor_stats),
+        analysis_since=window_start,
+        analysis_until=window_end,
+    )
+
+    if config.title:
+        metadata = replace(metadata, name=config.title)
+
+    report_data = ReportData(
+        metadata=metadata,
+        ranked_contributors=ranked_contributors,
+        commits=commits,
+    )
+
+    renderer = Renderer()
+    return renderer.render(report_data, config.output_path)

--- a/src/reveille/templates/report.html.j2
+++ b/src/reveille/templates/report.html.j2
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ data.metadata.name }} -- Reveille Report</title>
+    <style>
+        :root {
+            --color-primary:        #1e40af;
+            --color-primary-light:  #dbeafe;
+            --color-surface:        #f8fafc;
+            --color-border:         #e2e8f0;
+            --color-text-primary:   #0f172a;
+            --color-text-secondary: #475569;
+            --color-positive:       #059669;
+            --color-negative:       #dc2626;
+            --color-tier-7:         #0f172a;
+            --color-tier-6:         #1e3a8a;
+            --color-tier-5:         #1d4ed8;
+            --color-tier-4:         #0891b2;
+            --color-tier-3:         #059669;
+            --color-tier-2:         #d97706;
+            --color-tier-1:         #64748b;
+        }
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                         'Helvetica Neue', Arial, sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            color: var(--color-text-primary);
+            background: #ffffff;
+        }
+        .page {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 40px 32px 64px;
+        }
+        /* ---- Header ---- */
+        .report-header {
+            border-bottom: 2px solid var(--color-primary);
+            padding-bottom: 24px;
+            margin-bottom: 32px;
+        }
+        .report-header h1 {
+            font-size: 26px;
+            font-weight: 700;
+            color: var(--color-text-primary);
+            letter-spacing: -0.3px;
+        }
+        .report-subtitle {
+            font-size: 13px;
+            color: var(--color-text-secondary);
+            margin-top: 2px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            font-weight: 500;
+        }
+        .report-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 24px;
+            margin-top: 14px;
+            font-size: 13px;
+            color: var(--color-text-secondary);
+        }
+        .report-meta span strong {
+            color: var(--color-text-primary);
+            font-weight: 600;
+        }
+        /* ---- Section headings ---- */
+        .section {
+            margin-bottom: 40px;
+        }
+        .section-title {
+            font-size: 13px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.8px;
+            color: var(--color-text-secondary);
+            border-bottom: 1px solid var(--color-border);
+            padding-bottom: 8px;
+            margin-bottom: 20px;
+        }
+        /* ---- Summary cards ---- */
+        .summary-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 16px;
+            margin-bottom: 40px;
+        }
+        .summary-card {
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            border-radius: 6px;
+            padding: 18px 20px;
+        }
+        .summary-card .value {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--color-primary);
+            line-height: 1.1;
+        }
+        .summary-card .label {
+            font-size: 12px;
+            color: var(--color-text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-top: 4px;
+            font-weight: 500;
+        }
+        /* ---- Chart containers ---- */
+        .chart-container {
+            background: #ffffff;
+            border: 1px solid var(--color-border);
+            border-radius: 6px;
+            padding: 16px 16px 8px;
+            margin-bottom: 20px;
+        }
+        .chart-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+        }
+        .chart-empty {
+            color: var(--color-text-secondary);
+            font-style: italic;
+            padding: 20px;
+            text-align: center;
+        }
+        /* ---- Ranking table ---- */
+        .ranking-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 13px;
+        }
+        .ranking-table thead tr {
+            background: var(--color-surface);
+            border-bottom: 2px solid var(--color-border);
+        }
+        .ranking-table th {
+            padding: 10px 14px;
+            text-align: left;
+            font-weight: 600;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: var(--color-text-secondary);
+            white-space: nowrap;
+        }
+        .ranking-table td {
+            padding: 10px 14px;
+            border-bottom: 1px solid var(--color-border);
+            vertical-align: middle;
+        }
+        .ranking-table tbody tr:last-child td {
+            border-bottom: none;
+        }
+        .ranking-table tbody tr:hover td {
+            background: var(--color-surface);
+        }
+        .rank-number {
+            font-weight: 700;
+            color: var(--color-text-secondary);
+            font-size: 12px;
+        }
+        .contributor-name {
+            font-weight: 600;
+        }
+        .contributor-email {
+            font-size: 11px;
+            color: var(--color-text-secondary);
+            display: block;
+        }
+        .tier-badge {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 3px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+            color: #ffffff;
+            white-space: nowrap;
+        }
+        .tier-7 { background: var(--color-tier-7); }
+        .tier-6 { background: var(--color-tier-6); }
+        .tier-5 { background: var(--color-tier-5); }
+        .tier-4 { background: var(--color-tier-4); }
+        .tier-3 { background: var(--color-tier-3); }
+        .tier-2 { background: var(--color-tier-2); }
+        .tier-1 { background: var(--color-tier-1); }
+        .tier-0 { background: var(--color-tier-1); }
+        .num-positive { color: var(--color-positive); font-weight: 500; }
+        .num-negative { color: var(--color-negative); font-weight: 500; }
+        .score-bar-container {
+            width: 80px;
+            background: var(--color-border);
+            border-radius: 2px;
+            height: 6px;
+            display: inline-block;
+            vertical-align: middle;
+        }
+        .score-bar-fill {
+            height: 100%;
+            background: var(--color-primary);
+            border-radius: 2px;
+        }
+        /* ---- Footer ---- */
+        .report-footer {
+            margin-top: 48px;
+            padding-top: 16px;
+            border-top: 1px solid var(--color-border);
+            font-size: 11px;
+            color: var(--color-text-secondary);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        @media (max-width: 768px) {
+            .chart-row { grid-template-columns: 1fr; }
+            .report-meta { gap: 12px; }
+        }
+    </style>
+    <script>{{ plotly_js | safe }}</script>
+</head>
+<body>
+<div class="page">
+
+    <!-- ============================================================ -->
+    <!-- Header                                                       -->
+    <!-- ============================================================ -->
+    <header class="report-header">
+        <h1>{{ data.metadata.name }}</h1>
+        <p class="report-subtitle">Repository Performance Report</p>
+        <div class="report-meta">
+            {% if data.metadata.remote_url %}
+            <span><strong>Remote:</strong> {{ data.metadata.remote_url }}</span>
+            {% endif %}
+            <span><strong>Branch:</strong> {{ data.metadata.default_branch }}</span>
+            <span><strong>Period:</strong>
+                {{ data.metadata.analysis_since }} to {{ data.metadata.analysis_until }}
+            </span>
+            <span><strong>Generated:</strong> {{ generated_at }}</span>
+        </div>
+    </header>
+
+    <!-- ============================================================ -->
+    <!-- Summary Cards                                                -->
+    <!-- ============================================================ -->
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="value">{{ data.metadata.total_commits }}</div>
+            <div class="label">Total Commits</div>
+        </div>
+        <div class="summary-card">
+            <div class="value">{{ data.metadata.unique_contributors }}</div>
+            <div class="label">Contributors</div>
+        </div>
+        <div class="summary-card">
+            <div class="value">{{ derived.bus_factor }}</div>
+            <div class="label">Bus Factor</div>
+        </div>
+        <div class="summary-card">
+            <div class="value">{{ derived.longest_inactive_streak }}</div>
+            <div class="label">Max Inactive Days</div>
+        </div>
+        <div class="summary-card">
+            <div class="value">
+                {% if data.ranked_contributors %}
+                    {{ data.ranked_contributors[0].stats.name.split()[0] }}
+                {% else %}
+                    --
+                {% endif %}
+            </div>
+            <div class="label">Top Contributor</div>
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- Activity Heatmap                                             -->
+    <!-- ============================================================ -->
+    <div class="section">
+        <h2 class="section-title">Commit Activity Heatmap</h2>
+        <div class="chart-container">
+            {{ charts.heatmap | safe }}
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- Commit Timeline                                              -->
+    <!-- ============================================================ -->
+    <div class="section">
+        <h2 class="section-title">Weekly Commit Timeline</h2>
+        <div class="chart-container">
+            {{ charts.timeline | safe }}
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- Contributor Rankings                                         -->
+    <!-- ============================================================ -->
+    <div class="section">
+        <h2 class="section-title">Contributor Rankings</h2>
+        <div style="overflow-x: auto;">
+            <table class="ranking-table">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>Contributor</th>
+                        <th>Tier</th>
+                        <th style="text-align:right">Commits</th>
+                        <th style="text-align:right">Lines Added</th>
+                        <th style="text-align:right">Lines Deleted</th>
+                        <th style="text-align:right">Net Lines</th>
+                        <th style="text-align:right">Active Days</th>
+                        <th>Last Commit</th>
+                        <th>Score</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for contributor in data.ranked_contributors %}
+                    <tr>
+                        <td class="rank-number">{{ loop.index }}</td>
+                        <td>
+                            <span class="contributor-name">{{ contributor.stats.name }}</span>
+                            <span class="contributor-email">{{ contributor.stats.email }}</span>
+                        </td>
+                        <td>
+                            <span class="tier-badge tier-{{ contributor.tier }}">
+                                {% if contributor.tier > 0 %}
+                                    {{ contributor.tier_designation }}
+                                {% else %}
+                                    --
+                                {% endif %}
+                            </span>
+                        </td>
+                        <td style="text-align:right">{{ contributor.stats.commit_count }}</td>
+                        <td style="text-align:right" class="num-positive">
+                            +{{ contributor.stats.lines_added | int }}
+                        </td>
+                        <td style="text-align:right" class="num-negative">
+                            -{{ contributor.stats.lines_deleted | int }}
+                        </td>
+                        <td style="text-align:right">
+                            {% if contributor.stats.net_lines >= 0 %}
+                                <span class="num-positive">+{{ contributor.stats.net_lines }}</span>
+                            {% else %}
+                                <span class="num-negative">{{ contributor.stats.net_lines }}</span>
+                            {% endif %}
+                        </td>
+                        <td style="text-align:right">{{ contributor.stats.active_days }}</td>
+                        <td>{{ contributor.stats.last_commit_date }}</td>
+                        <td>
+                            {% if contributor.tier > 0 %}
+                            <div class="score-bar-container">
+                                <div class="score-bar-fill"
+                                     style="width: {{ (contributor.composite_score * 100) | int }}%">
+                                </div>
+                            </div>
+                            <span style="font-size:11px; color: var(--color-text-secondary);
+                                         margin-left: 6px;">
+                                {{ "%.2f" | format(contributor.composite_score) }}
+                            </span>
+                            {% else %}
+                            <span style="color: var(--color-text-secondary);">--</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- Lines Changed and Commit Volume Charts                       -->
+    <!-- ============================================================ -->
+    <div class="section">
+        <h2 class="section-title">Contribution Breakdown</h2>
+        <div class="chart-row">
+            <div class="chart-container">
+                <p style="font-size:12px; font-weight:600; color: var(--color-text-secondary);
+                           text-transform:uppercase; letter-spacing:0.5px; margin-bottom:8px;">
+                    Commits by Contributor
+                </p>
+                {{ charts.contributor_commits | safe }}
+            </div>
+            <div class="chart-container">
+                <p style="font-size:12px; font-weight:600; color: var(--color-text-secondary);
+                           text-transform:uppercase; letter-spacing:0.5px; margin-bottom:8px;">
+                    Lines Changed by Contributor
+                </p>
+                {{ charts.contributor_lines | safe }}
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- Footer                                                       -->
+    <!-- ============================================================ -->
+    <footer class="report-footer">
+        <span>Generated by Reveille</span>
+        <span>{{ data.metadata.analysis_since }} -- {{ data.metadata.analysis_until }}</span>
+    </footer>
+
+</div>
+</body>
+</html>

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -1,0 +1,275 @@
+"""Unit tests for reveille.adapters.renderer module-level functions.
+
+The Renderer class itself is covered by integration tests on feat/cli.
+These tests exercise the chart construction and derived metric helper
+functions directly, as they are pure or near-pure functions whose
+correctness can be verified without a running Jinja2 environment.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from reveille.adapters.renderer import (
+    _build_contributor_commits_chart,
+    _build_contributor_lines_chart,
+    _build_heatmap_chart,
+    _build_timeline_chart,
+    _compute_bus_factor,
+    _compute_longest_inactive_streak,
+)
+from reveille.domain.models import Commit, ContributorStats, RankedContributor
+
+# ------------------------------------------------------------------
+# Shared helpers
+# ------------------------------------------------------------------
+
+def _make_commit(
+    date: datetime.date,
+    email: str = "a@example.com",
+    lines_added: int = 10,
+    lines_deleted: int = 2,
+) -> Commit:
+    return Commit(
+        sha=f"{email[:3]}{date.isoformat()}",
+        author_name="Author",
+        author_email=email,
+        timestamp=datetime.datetime(
+            date.year, date.month, date.day, 12, 0,
+            tzinfo=datetime.UTC,
+        ),
+        lines_added=lines_added,
+        lines_deleted=lines_deleted,
+    )
+
+
+def _make_ranked(
+    name: str,
+    commit_count: int,
+    lines_added: int = 200,
+    lines_deleted: int = 50,
+    tier: int = 4,
+    designation: str = "Senior Specialist",
+) -> RankedContributor:
+    stats = ContributorStats(
+        name=name,
+        email=f"{name.lower()}@example.com",
+        commit_count=commit_count,
+        lines_added=lines_added,
+        lines_deleted=lines_deleted,
+        active_days=max(1, commit_count // 2),
+        first_commit_date=datetime.date(2024, 1, 1),
+        last_commit_date=datetime.date(2024, 3, 31),
+    )
+    return RankedContributor(
+        stats=stats,
+        composite_score=0.5,
+        percentile=50.0,
+        tier=tier,
+        tier_designation=designation,
+    )
+
+
+# ------------------------------------------------------------------
+# _compute_bus_factor
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestComputeBusFactor:
+    """Tests for the bus factor derived metric helper."""
+
+    def test_empty_ranked_returns_zero(self) -> None:
+        assert _compute_bus_factor([]) == 0
+
+    def test_single_contributor_returns_one(self) -> None:
+        ranked = [_make_ranked("Alice", commit_count=20)]
+        assert _compute_bus_factor(ranked) == 1
+
+    def test_two_equal_contributors_returns_one(self) -> None:
+        ranked = [
+            _make_ranked("Alice", commit_count=10),
+            _make_ranked("Bob", commit_count=10),
+        ]
+        # One contributor accounts for 50% of commits (10/20 = 50%).
+        assert _compute_bus_factor(ranked) == 1
+
+    def test_skewed_distribution_returns_one(self) -> None:
+        ranked = [
+            _make_ranked("Alice", commit_count=90),
+            _make_ranked("Bob", commit_count=5),
+            _make_ranked("Carol", commit_count=5),
+        ]
+        assert _compute_bus_factor(ranked) == 1
+
+    def test_even_distribution_across_four_returns_two(self) -> None:
+        ranked = [
+            _make_ranked("Alice", commit_count=25),
+            _make_ranked("Bob", commit_count=25),
+            _make_ranked("Carol", commit_count=25),
+            _make_ranked("Dan", commit_count=25),
+        ]
+        # Top contributor = 25%, top two = 50%. Bus factor is 2.
+        assert _compute_bus_factor(ranked) == 2
+
+    def test_zero_total_commits_returns_zero(self) -> None:
+        ranked = [_make_ranked("Alice", commit_count=0)]
+        assert _compute_bus_factor(ranked) == 0
+
+
+# ------------------------------------------------------------------
+# _compute_longest_inactive_streak
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestComputeLongestInactiveStreak:
+    """Tests for the inactive streak derived metric helper."""
+
+    def test_no_commits_returns_full_window_length(self) -> None:
+        streak = _compute_longest_inactive_streak(
+            commits=[],
+            window_start=datetime.date(2024, 1, 1),
+            window_end=datetime.date(2024, 1, 10),
+        )
+        assert streak == 9
+
+    def test_commits_every_day_returns_zero(self) -> None:
+        start = datetime.date(2024, 1, 1)
+        end = datetime.date(2024, 1, 5)
+        commits = [
+            _make_commit(start + datetime.timedelta(days=i))
+            for i in range(5)
+        ]
+        streak = _compute_longest_inactive_streak(
+            commits=commits,
+            window_start=start,
+            window_end=end,
+        )
+        assert streak == 0
+
+    def test_gap_in_the_middle_is_detected(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 1, 1)),
+            _make_commit(datetime.date(2024, 1, 8)),
+        ]
+        streak = _compute_longest_inactive_streak(
+            commits=commits,
+            window_start=datetime.date(2024, 1, 1),
+            window_end=datetime.date(2024, 1, 10),
+        )
+        # Days 2-7 are inactive: 6 consecutive days.
+        assert streak == 6
+
+    def test_gap_at_start_of_window_is_detected(self) -> None:
+        commits = [_make_commit(datetime.date(2024, 1, 5))]
+        streak = _compute_longest_inactive_streak(
+            commits=commits,
+            window_start=datetime.date(2024, 1, 1),
+            window_end=datetime.date(2024, 1, 5),
+        )
+        # Days 1-4 are inactive: 4 consecutive days.
+        assert streak == 4
+
+
+# ------------------------------------------------------------------
+# Chart builders -- structural tests
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestBuildTimelineChart:
+    """Tests for the weekly commit timeline chart builder."""
+
+    def test_empty_commits_returns_placeholder(self) -> None:
+        result = _build_timeline_chart([])
+        assert "chart-empty" in result
+
+    def test_with_commits_returns_non_empty_html(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 1, 8)),
+            _make_commit(datetime.date(2024, 1, 15)),
+            _make_commit(datetime.date(2024, 2, 5)),
+        ]
+        result = _build_timeline_chart(commits)
+        assert len(result) > 0
+        assert "<div" in result
+
+    def test_aggregates_commits_within_same_week(self) -> None:
+        # Two commits in the same week should not raise any errors.
+        commits = [
+            _make_commit(datetime.date(2024, 1, 8)),
+            _make_commit(datetime.date(2024, 1, 9)),
+        ]
+        result = _build_timeline_chart(commits)
+        assert "<div" in result
+
+
+@pytest.mark.unit
+class TestBuildHeatmapChart:
+    """Tests for the calendar heatmap chart builder."""
+
+    def test_empty_commits_returns_placeholder(self) -> None:
+        result = _build_heatmap_chart([])
+        assert "chart-empty" in result
+
+    def test_with_commits_returns_non_empty_html(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 1, 8)),
+            _make_commit(datetime.date(2024, 1, 15)),
+        ]
+        result = _build_heatmap_chart(commits)
+        assert "<div" in result
+
+    def test_multiple_days_of_week_handled(self) -> None:
+        start = datetime.date(2024, 1, 7)
+        commits = [
+            _make_commit(start + datetime.timedelta(days=i))
+            for i in range(7)
+        ]
+        result = _build_heatmap_chart(commits)
+        assert "<div" in result
+
+
+@pytest.mark.unit
+class TestBuildContributorCommitsChart:
+    """Tests for the horizontal commit count bar chart builder."""
+
+    def test_empty_ranked_returns_placeholder(self) -> None:
+        result = _build_contributor_commits_chart([])
+        assert "chart-empty" in result
+
+    def test_single_contributor_returns_chart(self) -> None:
+        ranked = [_make_ranked("Alice", commit_count=15)]
+        result = _build_contributor_commits_chart(ranked)
+        assert "<div" in result
+
+    def test_multiple_contributors_return_chart(self) -> None:
+        ranked = [
+            _make_ranked("Alice", commit_count=30),
+            _make_ranked("Bob", commit_count=12),
+            _make_ranked("Carol", commit_count=5),
+        ]
+        result = _build_contributor_commits_chart(ranked)
+        assert "<div" in result
+
+
+@pytest.mark.unit
+class TestBuildContributorLinesChart:
+    """Tests for the grouped lines changed bar chart builder."""
+
+    def test_empty_ranked_returns_placeholder(self) -> None:
+        result = _build_contributor_lines_chart([])
+        assert "chart-empty" in result
+
+    def test_single_contributor_returns_chart(self) -> None:
+        ranked = [_make_ranked("Alice", commit_count=10, lines_added=500, lines_deleted=80)]
+        result = _build_contributor_lines_chart(ranked)
+        assert "<div" in result
+
+    def test_multiple_contributors_return_chart(self) -> None:
+        ranked = [
+            _make_ranked("Alice", commit_count=20, lines_added=1200, lines_deleted=300),
+            _make_ranked("Bob", commit_count=8, lines_added=400, lines_deleted=100),
+        ]
+        result = _build_contributor_lines_chart(ranked)
+        assert "<div" in result

--- a/tests/unit/services/test_report.py
+++ b/tests/unit/services/test_report.py
@@ -1,0 +1,281 @@
+"""Unit tests for reveille.services.report.
+
+The application service is an orchestrator with no logic of its own
+beyond wiring. These tests verify the orchestration contracts using
+mocks, confirming that the service calls its collaborators correctly
+and handles their outputs as expected.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from reveille.config import ReportConfig
+from reveille.domain.models import (
+    Commit,
+    ContributorStats,
+    RankedContributor,
+    ReportData,
+    RepositoryMetadata,
+)
+from reveille.services.report import generate_report
+
+# ------------------------------------------------------------------
+# Shared fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture()
+def minimal_config(tmp_path: Path) -> ReportConfig:
+    """A minimal ReportConfig pointing at a temp directory."""
+    return ReportConfig(
+        repo_path=tmp_path,
+        output_path=tmp_path / "report.html",
+        since=datetime.date(2024, 1, 1),
+        until=datetime.date(2024, 3, 31),
+        ranking_enabled=True,
+    )
+
+
+@pytest.fixture()
+def sample_commit() -> Commit:
+    """A single Commit instance for use in service unit tests."""
+    return Commit(
+        sha="abc123",
+        author_name="Alice",
+        author_email="alice@example.com",
+        timestamp=datetime.datetime(2024, 2, 15, 10, 0, tzinfo=datetime.UTC),
+        lines_added=30,
+        lines_deleted=5,
+    )
+
+
+@pytest.fixture()
+def sample_stats(sample_commit: Commit) -> ContributorStats:
+    """A single ContributorStats instance derived from sample_commit."""
+    return ContributorStats(
+        name="Alice",
+        email="alice@example.com",
+        commit_count=1,
+        lines_added=30,
+        lines_deleted=5,
+        active_days=1,
+        first_commit_date=datetime.date(2024, 2, 15),
+        last_commit_date=datetime.date(2024, 2, 15),
+    )
+
+
+@pytest.fixture()
+def sample_ranked(sample_stats: ContributorStats) -> RankedContributor:
+    """A RankedContributor at the Commander tier for use in service tests."""
+    return RankedContributor(
+        stats=sample_stats,
+        composite_score=1.0,
+        percentile=100.0,
+        tier=7,
+        tier_designation="Commander",
+    )
+
+
+@pytest.fixture()
+def sample_metadata() -> RepositoryMetadata:
+    """A RepositoryMetadata instance for use in service tests."""
+    return RepositoryMetadata(
+        name="test-repo",
+        remote_url=None,
+        default_branch="main",
+        total_commits=1,
+        unique_contributors=1,
+        analysis_since=datetime.date(2024, 1, 1),
+        analysis_until=datetime.date(2024, 3, 31),
+        generated_at=datetime.datetime(
+            2024, 4, 1, 12, 0, tzinfo=datetime.UTC
+        ),
+    )
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestGenerateReport:
+    """Tests for the generate_report orchestration function."""
+
+    def test_returns_output_path_from_renderer(
+        self,
+        minimal_config: ReportConfig,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+        tmp_path: Path,
+    ) -> None:
+        expected_path = tmp_path / "report.html"
+
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+            mock_renderer.return_value.render.return_value = expected_path
+
+            result = generate_report(minimal_config)
+
+        assert result == expected_path
+
+    def test_rank_contributors_called_when_ranking_enabled(
+        self,
+        minimal_config: ReportConfig,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+            mock_renderer.return_value.render.return_value = Path("out.html")
+
+            generate_report(minimal_config)
+
+        mock_rank.assert_called_once()
+
+    def test_rank_contributors_not_called_when_ranking_disabled(
+        self,
+        tmp_path: Path,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        config = ReportConfig(
+            repo_path=tmp_path,
+            output_path=tmp_path / "report.html",
+            since=datetime.date(2024, 1, 1),
+            until=datetime.date(2024, 3, 31),
+            ranking_enabled=False,
+        )
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_renderer.return_value.render.return_value = Path("out.html")
+
+            generate_report(config)
+
+        mock_rank.assert_not_called()
+
+    def test_title_override_replaces_metadata_name(
+        self,
+        tmp_path: Path,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        config = ReportConfig(
+            repo_path=tmp_path,
+            output_path=tmp_path / "report.html",
+            since=datetime.date(2024, 1, 1),
+            until=datetime.date(2024, 3, 31),
+            title="Q1 Engineering Report",
+        )
+        captured: list[ReportData] = []
+
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+
+            def capture_render(data: ReportData, path: Path) -> Path:
+                captured.append(data)
+                return path
+
+            mock_renderer.return_value.render.side_effect = capture_render
+
+            generate_report(config)
+
+        assert len(captured) == 1
+        assert captured[0].metadata.name == "Q1 Engineering Report"
+
+    def test_window_start_uses_config_since_when_provided(
+        self,
+        minimal_config: ReportConfig,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+            mock_renderer.return_value.render.return_value = Path("out.html")
+
+            generate_report(minimal_config)
+
+        call_kwargs = reader_instance.aggregate_contributor_stats.call_args
+        assert call_kwargs.kwargs["window_start"] == datetime.date(2024, 1, 1)
+
+    def test_renderer_receives_commits_in_report_data(
+        self,
+        minimal_config: ReportConfig,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        captured: list[ReportData] = []
+
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+
+            def capture(data: ReportData, path: Path) -> Path:
+                captured.append(data)
+                return path
+
+            mock_renderer.return_value.render.side_effect = capture
+
+            generate_report(minimal_config)
+
+        assert captured[0].commits == [sample_commit]


### PR DESCRIPTION
…service

- Implement Renderer with Jinja2 PackageLoader and four Plotly chart builders
- Implement activity heatmap, weekly timeline, contributor commits, lines changed charts
- Implement derived stats: bus factor and longest inactive streak
- Add professional HTML template with embedded Plotly JS, summary cards, ranking table with tier badges, and contribution breakdown charts
- Implement generate_report service orchestrating all layers end-to-end
- Add unit tests for service orchestration using mock collaborators
- Add unit tests for renderer module-level chart and metric helpers
- Fix _base_layout return type to dict[str, Any] resolving Pylance warnings
- Raise coverage threshold to 75