### PR TITLE
feat(cli): wire TOML config loading, e2e test suite, and environment …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ __pypackages__/
 .cache/
 .coverage
 .coverage.*
+.coverage_data/
 htmlcov/
 coverage.xml
 *.cover

--- a/poetry.lock
+++ b/poetry.lock
@@ -24,13 +24,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.2.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613"},
-    {file = "click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2"},
+    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
+    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
 ]
 
 [package.dependencies]
@@ -175,6 +175,20 @@ files = [
     {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
     {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
 ]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "filelock"
@@ -900,6 +914,26 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1186,4 +1220,4 @@ python-discovery = ">=1.2.2"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "996da644703f7a71e1d0c470ca67ca4e21c41a952434a1f98b1376b53a9e0ec1"
+content-hash = "2b10a1eaffc9a693074bcd747b47d39adb534118ac6ef4e96956e83404a7da23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,10 @@ packages = [
 python = "^3.11"
 
 # CLI Layer
+# Click 8.3 introduced a breaking change to Parameter.make_metavar() that
+# is incompatible with Typer 0.12.x. Pin to <8.3 until Typer is upgraded.
 typer = { version = "^0.12.0", extras = ["all"] }
+click = ">=8.0.0,<8.3.0"
 
 # Git Data Layer
 gitpython = "^3.1.40"
@@ -82,6 +85,7 @@ optional = false
 # Testing Framework
 pytest = "^8.0.0"
 pytest-cov = "^5.0.0"
+pytest-xdist = "^3.5.0"
 
 # Type Checking
 mypy = "^1.8.0"
@@ -217,6 +221,8 @@ addopts = [
     "--verbose",
     "--strict-markers",
     "--strict-config",
+    "-n",
+    "auto",
     "--cov=reveille",
     "--cov-report=term-missing",
     "--cov-report=html",
@@ -233,6 +239,7 @@ filterwarnings = [
     "error",
     "ignore::DeprecationWarning",
     "ignore::PendingDeprecationWarning",
+    "ignore::coverage.exceptions.CoverageWarning",
 ]
 
 
@@ -243,6 +250,8 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["src/reveille"]
 branch = true
+parallel = true
+data_file = ".coverage_data/.coverage"
 omit = [
     "*/tests/*",
     "*/__init__.py",
@@ -252,9 +261,7 @@ omit = [
 precision = 2
 show_missing = true
 
-# Raised progressively as feature branches land:
-#   feat/cli -> 80
-fail_under = 75
+fail_under = 80
 
 exclude_lines = [
     "pragma: no cover",

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -19,7 +19,7 @@ import typer
 
 from reveille import __version__
 from reveille.config import ReportConfig
-from reveille.exceptions import RevelleError
+from reveille.exceptions import ConfigurationError, RevelleError
 
 app = typer.Typer(
     name="reveille",
@@ -49,6 +49,66 @@ def main(
     ] = None,
 ) -> None:
     """Reveille -- Git Repository Intelligence."""
+
+
+def _merge_cli_flags(
+    config_kwargs: dict[str, object],
+    repo: Path,
+    output: Path,
+    since: str | None,
+    until: str | None,
+    branch: str | None,
+    title: str | None,
+    exclude_author: list[str] | None,
+    min_commits: int,
+    no_ranking: bool,
+) -> dict[str, object]:
+    """Merge CLI flag values into the base configuration dict.
+
+    CLI flag values always take precedence over configuration file values.
+    Flags that were not explicitly set by the user (i.e. still at their
+    default) are only applied when no configuration file provided a value.
+
+    Args:
+        config_kwargs: Base kwargs loaded from a TOML file, or empty dict.
+        repo: Resolved repository path from --repo flag.
+        output: Output path from --output flag.
+        since: Raw since date string, or None if not provided.
+        until: Raw until date string, or None if not provided.
+        branch: Branch name, or None if not provided.
+        title: Report title override, or None if not provided.
+        exclude_author: List of authors to exclude, or None.
+        min_commits: Minimum commit threshold.
+        no_ranking: Whether ranking is disabled.
+
+    Returns:
+        A merged dict ready for ReportConfig construction.
+    """
+    merged = dict(config_kwargs)
+    merged["repo_path"] = repo.resolve()
+
+    if output != Path("reveille-report.html") or "output_path" not in merged:
+        # Default output is placed at the repository root, not the working directory.
+        if output == Path("reveille-report.html"):
+            merged["output_path"] = merged["repo_path"] / "reveille-report.html"  # type: ignore[operator]
+        else:
+            merged["output_path"] = output
+    if since is not None:
+        merged["since"] = _parse_date(since, "--since")
+    if until is not None:
+        merged["until"] = _parse_date(until, "--until")
+    if branch is not None:
+        merged["branch"] = branch
+    if title is not None:
+        merged["title"] = title
+    if exclude_author:
+        merged["exclude_authors"] = exclude_author
+    if min_commits != 1:
+        merged["min_commits"] = min_commits
+    if no_ranking:
+        merged["ranking_enabled"] = False
+
+    return merged
 
 
 @app.command()
@@ -92,31 +152,36 @@ def generate(
         bool,
         typer.Option("--no-ranking", help="Omit the contributor ranking table from the output."),
     ] = False,
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Path to a TOML configuration file."),
+    ] = None,
 ) -> None:
     """Generate an HTML performance report for the target repository."""
+    from reveille.config import load_config_from_toml
     from reveille.services.report import generate_report
 
-    since_date = _parse_date(since, "--since") if since else None
-    until_date = _parse_date(until, "--until") if until else None
+    config_kwargs: dict[str, object] = {}
+    if config is not None:
+        try:
+            config_kwargs = load_config_from_toml(config)
+        except ConfigurationError as exc:
+            typer.echo(f"Configuration error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+    merged = _merge_cli_flags(
+        config_kwargs, repo, output, since, until,
+        branch, title, exclude_author, min_commits, no_ranking,
+    )
 
     try:
-        config = ReportConfig(
-            repo_path=repo.resolve(),
-            output_path=output,
-            title=title,
-            branch=branch,
-            since=since_date,
-            until=until_date,
-            exclude_authors=exclude_author or [],
-            min_commits=min_commits,
-            ranking_enabled=not no_ranking,
-        )
+        report_config = ReportConfig(**merged)  # type: ignore[arg-type]
     except ValueError as exc:
         typer.echo(f"Configuration error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
     try:
-        written_path = generate_report(config)
+        written_path = generate_report(report_config)
         typer.echo(f"Report written to: {written_path}")
     except RevelleError as exc:
         typer.echo(f"Error: {exc}", err=True)

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -9,9 +9,13 @@ taking precedence over file values in all cases.
 from __future__ import annotations
 
 import datetime
+import tomllib
 from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
+
+from reveille.exceptions import ConfigurationError
 
 
 class RankingWeights(BaseModel):
@@ -86,3 +90,111 @@ class ReportConfig(BaseModel):
                 f"since ({self.since}) must be earlier than until ({self.until})."
             )
         return self
+
+
+def load_config_from_toml(path: Path) -> dict[str, Any]:
+    """Load and flatten configuration values from a Reveille TOML file.
+
+    Reads the structured TOML format documented in the README and returns
+    a flat dict of keyword arguments suitable for constructing a ReportConfig.
+    Only keys present in the file are included in the returned dict -- absent
+    keys do not override CLI defaults.
+
+    Args:
+        path: Path to the TOML configuration file.
+
+    Returns:
+        A dict of ReportConfig-compatible keyword arguments.
+
+    Raises:
+        ConfigurationError: If the file does not exist, cannot be read,
+            is not valid TOML, or contains an invalid date string.
+    """
+    try:
+        with path.open("rb") as fh:
+            raw = tomllib.load(fh)
+    except FileNotFoundError as exc:
+        raise ConfigurationError(
+            f"Configuration file not found: '{path}'."
+        ) from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigurationError(
+            f"Configuration file is not valid TOML: {exc}"
+        ) from exc
+
+    kwargs: dict[str, Any] = {}
+    kwargs.update(_parse_report_section(raw.get("report", {})))
+    kwargs.update(_parse_filters_section(raw.get("filters", {})))
+    kwargs.update(_parse_ranking_section(raw.get("ranking", {})))
+    return kwargs
+
+
+def _parse_report_section(report: dict[str, Any]) -> dict[str, Any]:
+    """Parse the [report] section of a Reveille TOML configuration file.
+
+    Args:
+        report: The raw [report] table from the parsed TOML document.
+
+    Returns:
+        A partial kwargs dict for ReportConfig construction.
+
+    Raises:
+        ConfigurationError: If a date field contains an invalid ISO 8601 string.
+    """
+    kwargs: dict[str, Any] = {}
+    if "title" in report:
+        kwargs["title"] = str(report["title"])
+    if "output" in report:
+        kwargs["output_path"] = Path(str(report["output"]))
+    if "branch" in report:
+        kwargs["branch"] = str(report["branch"])
+    for field in ("since", "until"):
+        if field in report:
+            try:
+                kwargs[field] = datetime.date.fromisoformat(str(report[field]))
+            except ValueError as exc:
+                raise ConfigurationError(
+                    f"Invalid '{field}' date in configuration file: "
+                    f"'{report[field]}'. Expected YYYY-MM-DD."
+                ) from exc
+    return kwargs
+
+
+def _parse_filters_section(filters: dict[str, Any]) -> dict[str, Any]:
+    """Parse the [filters] section of a Reveille TOML configuration file.
+
+    Args:
+        filters: The raw [filters] table from the parsed TOML document.
+
+    Returns:
+        A partial kwargs dict for ReportConfig construction.
+    """
+    kwargs: dict[str, Any] = {}
+    if "min_commits" in filters:
+        kwargs["min_commits"] = int(filters["min_commits"])
+    if "exclude_authors" in filters:
+        kwargs["exclude_authors"] = list(filters["exclude_authors"])
+    return kwargs
+
+
+def _parse_ranking_section(ranking: dict[str, Any]) -> dict[str, Any]:
+    """Parse the [ranking] section of a Reveille TOML configuration file.
+
+    Args:
+        ranking: The raw [ranking] table from the parsed TOML document.
+
+    Returns:
+        A partial kwargs dict for ReportConfig construction.
+    """
+    kwargs: dict[str, Any] = {}
+    if "enabled" in ranking:
+        kwargs["ranking_enabled"] = bool(ranking["enabled"])
+    if "weights" in ranking:
+        w = ranking["weights"]
+        kwargs["ranking_weights"] = RankingWeights(
+            commits=float(w.get("commits", 0.30)),
+            lines=float(w.get("lines", 0.25)),
+            consistency=float(w.get("consistency", 0.25)),
+            recency=float(w.get("recency", 0.20)),
+        )
+    return kwargs

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1,0 +1,390 @@
+"""End-to-end tests for the Reveille CLI.
+
+These tests invoke the CLI through Typer's CliRunner, which executes
+the full application pipeline in-process: argument parsing, configuration
+validation, Git data extraction, ranking, and HTML rendering. They
+verify the externally observable contract: exit codes, stdout messages,
+and the structure of the generated HTML output file.
+
+Parallelism: tests run under pytest-xdist (-n auto). All fixtures use
+tmp_path_factory rather than tmp_path to remain safe across workers.
+The module-scoped default_report_content fixture generates the Plotly
+bundle once per worker, avoiding redundant full-pipeline invocations
+for tests that only inspect default output structure.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from reveille import __version__
+from reveille.cli import app
+
+runner = CliRunner()
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def e2e_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a minimal Git repository for end-to-end CLI testing.
+
+    Contains three commits from two contributors across a two-month window,
+    which is sufficient to exercise the full report generation pipeline.
+    Module-scoped so the repository is created once per worker.
+    """
+    repo_path = tmp_path_factory.mktemp("e2e_repo")
+
+    def run(args: list[str], env_override: dict[str, str] | None = None) -> None:
+        env = {**os.environ, **(env_override or {})}
+        subprocess.run(args, cwd=repo_path, check=True, capture_output=True, env=env)
+
+    alice = {
+        "GIT_AUTHOR_NAME": "Alice",
+        "GIT_AUTHOR_EMAIL": "alice@example.com",
+        "GIT_COMMITTER_NAME": "Alice",
+        "GIT_COMMITTER_EMAIL": "alice@example.com",
+        "GIT_COMMITTER_DATE": "2024-02-01T10:00:00+00:00",
+    }
+    bob = {
+        "GIT_AUTHOR_NAME": "Bob",
+        "GIT_AUTHOR_EMAIL": "bob@example.com",
+        "GIT_COMMITTER_NAME": "Bob",
+        "GIT_COMMITTER_EMAIL": "bob@example.com",
+        "GIT_COMMITTER_DATE": "2024-03-15T14:00:00+00:00",
+    }
+
+    run(["git", "init", "-b", "main"])
+    run(["git", "config", "user.email", "alice@example.com"])
+    run(["git", "config", "user.name", "Alice"])
+
+    (repo_path / "module_a.py").write_text("x = 1\ny = 2\n")
+    run(["git", "add", "."])
+    run(
+        ["git", "commit", "-m", "feat: initial commit",
+         "--date=2024-02-01T10:00:00+00:00"],
+        env_override=alice,
+    )
+
+    (repo_path / "module_b.py").write_text("a = 10\nb = 20\n")
+    run(["git", "add", "."])
+    run(
+        ["git", "commit", "-m", "feat: add module_b",
+         "--date=2024-03-15T14:00:00+00:00"],
+        env_override=bob,
+    )
+
+    (repo_path / "module_a.py").write_text("x = 1\ny = 2\nz = 3\n")
+    run(["git", "add", "."])
+    run(
+        ["git", "commit", "-m", "fix: add z variable",
+         "--date=2024-03-20T09:00:00+00:00"],
+        env_override={**alice, "GIT_COMMITTER_DATE": "2024-03-20T09:00:00+00:00"},
+    )
+
+    return repo_path
+
+
+@pytest.fixture(scope="module")
+def default_report_content(
+    e2e_repo: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> str:
+    """Generate the default report once and return its HTML content.
+
+    Shared across all tests that inspect default output structure to avoid
+    embedding the Plotly bundle multiple times per worker. Tests that
+    exercise distinct flags generate their own outputs independently.
+    """
+    output = tmp_path_factory.mktemp("default_report") / "report.html"
+    result = runner.invoke(
+        app,
+        ["generate", "--repo", str(e2e_repo), "--output", str(output)],
+    )
+    assert result.exit_code == 0, result.output
+    return output.read_text(encoding="utf-8")
+
+
+# ------------------------------------------------------------------
+# Version command
+# ------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestVersionCommand:
+    """Tests for the reveille --version flag."""
+
+    def test_version_outputs_correct_string(self) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.stdout
+
+    def test_version_flag_short_form(self) -> None:
+        result = runner.invoke(app, ["-v"])
+        assert result.exit_code == 0
+        assert __version__ in result.stdout
+
+
+# ------------------------------------------------------------------
+# Validate command
+# ------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestValidateCommand:
+    """Tests for the reveille validate command."""
+
+    def test_valid_repository_exits_zero(
+        self, e2e_repo: Path
+    ) -> None:
+        result = runner.invoke(app, ["validate", "--repo", str(e2e_repo)])
+        assert result.exit_code == 0
+        assert "valid" in result.stdout.lower()
+
+    def test_non_git_directory_exits_nonzero(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        plain = tmp_path_factory.mktemp("plain_dir")
+        result = runner.invoke(app, ["validate", "--repo", str(plain)])
+        assert result.exit_code == 1
+
+    def test_non_git_directory_reports_error_in_output(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        plain = tmp_path_factory.mktemp("plain_dir_err")
+        result = runner.invoke(app, ["validate", "--repo", str(plain)])
+        assert "Error" in result.output
+
+
+# ------------------------------------------------------------------
+# Generate command
+# ------------------------------------------------------------------
+
+@pytest.mark.e2e
+class TestGenerateCommand:
+    """Tests for the reveille generate command."""
+
+    # -- Default output structure (shared fixture, no redundant rendering) --
+
+    def test_generates_html_file_at_default_path(
+        self, default_report_content: str
+    ) -> None:
+        assert len(default_report_content) > 0
+
+    def test_output_is_valid_html(
+        self, default_report_content: str
+    ) -> None:
+        assert "<!DOCTYPE html>" in default_report_content
+        assert "</html>" in default_report_content
+
+    def test_output_contains_plotly_bundle(
+        self, default_report_content: str
+    ) -> None:
+        assert "plotly" in default_report_content.lower()
+
+    def test_output_contains_contributor_names(
+        self, default_report_content: str
+    ) -> None:
+        assert "Alice" in default_report_content
+        assert "Bob" in default_report_content
+
+    def test_output_file_has_no_external_script_tags(
+        self, default_report_content: str
+    ) -> None:
+        assert 'src="http' not in default_report_content
+        assert "src='http" not in default_report_content
+
+    # -- Distinct invocations (different flags, cannot share) --
+
+    def test_stdout_reports_output_path(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        output = tmp_path_factory.mktemp("stdout_test") / "report.html"
+        result = runner.invoke(
+            app,
+            ["generate", "--repo", str(e2e_repo), "--output", str(output)],
+        )
+        assert result.exit_code == 0
+        assert "Report written to" in result.stdout
+
+    def test_title_override_appears_in_output(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        output = tmp_path_factory.mktemp("title_test") / "report.html"
+        runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--title", "Q1 Engineering Review",
+            ],
+        )
+        content = output.read_text(encoding="utf-8")
+        assert "Q1 Engineering Review" in content
+
+    def test_no_ranking_flag_completes_successfully(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        output = tmp_path_factory.mktemp("no_ranking_test") / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--no-ranking",
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
+
+    def test_since_filter_restricts_analysis_window(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        output = tmp_path_factory.mktemp("since_test") / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--since", "2024-03-01",
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
+
+    # -- Error path tests (no rendering, fast) --
+
+    def test_invalid_since_date_exits_nonzero(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        output = tmp_path_factory.mktemp("invalid_since") / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--since", "not-a-date",
+            ],
+        )
+        assert result.exit_code == 1
+
+    def test_since_after_until_exits_nonzero(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        output = tmp_path_factory.mktemp("inverted_dates") / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--since", "2024-06-01",
+                "--until", "2024-01-01",
+            ],
+        )
+        assert result.exit_code == 1
+
+    def test_config_file_title_appears_in_output(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("config_title_test")
+        output = base / "report.html"
+        config_file = base / "reveille.toml"
+        config_file.write_text(
+            '[report]\ntitle = "TOML Config Title"\n',
+            encoding="utf-8",
+        )
+        runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--config", str(config_file),
+            ],
+        )
+        content = output.read_text(encoding="utf-8")
+        assert "TOML Config Title" in content
+
+    def test_cli_title_overrides_config_file_title(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("cli_override_test")
+        output = base / "report.html"
+        config_file = base / "reveille.toml"
+        config_file.write_text(
+            '[report]\ntitle = "Config Title"\n',
+            encoding="utf-8",
+        )
+        runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(output),
+                "--config", str(config_file),
+                "--title", "CLI Title",
+            ],
+        )
+        content = output.read_text(encoding="utf-8")
+        assert "CLI Title" in content
+        assert "Config Title" not in content
+
+    def test_nonexistent_config_file_exits_nonzero(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("missing_config_test")
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(e2e_repo),
+                "--output", str(base / "report.html"),
+                "--config", str(base / "nonexistent.toml"),
+            ],
+        )
+        assert result.exit_code == 1
+
+    def test_invalid_repo_path_exits_nonzero(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        base = tmp_path_factory.mktemp("invalid_repo_test")
+        plain = base / "not_a_repo"
+        plain.mkdir()
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo", str(plain),
+                "--output", str(base / "report.html"),
+            ],
+        )
+        assert result.exit_code == 1


### PR DESCRIPTION
…fixes

- Add load_config_from_toml to config.py using stdlib tomllib
- Extract _parse_report_section, _parse_filters_section, _parse_ranking_section helpers to satisfy complexity threshold
- Extract _merge_cli_flags helper for the generate command
- Wire --config flag with CLI-over-file precedence
- Default output path resolves to repository root rather than working directory
- Add 19 end-to-end tests covering version, validate, and generate commands
- Verify HTML output contract: self-contained, no external script src, Plotly bundle embedded, contributor names present, config override precedence
- Add pytest-xdist for parallel test execution (-n auto)
- Add default_report_content module-scoped fixture to avoid redundant renders
- Pin click<8.3.0 to resolve Typer 0.12.x incompatibility with Click 8.3
- Enable coverage parallel mode and direct worker data files to .coverage_data/
- Add .coverage_data/ to .gitignore
- Raise coverage threshold to 80