### PR TITLE
fix(tests): correct external script assertion to prevent difflib timeout on Plotly bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction
       - name: Run pytest
-        run: poetry run pytest --cov=reveille --cov-report=xml
+        run: poetry run pytest -n auto --timeout=120 --cov=reveille --cov-report=xml
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         if: matrix.python-version == '3.11'

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ typecheck:  ## Run mypy in strict mode
 # Testing
 # ------------------------------------------------------------------
 
-test:  ## Run the full test suite
-	poetry run pytest
+test:  ## Run the full test suite (parallel, no coverage instrumentation)
+    poetry run pytest -n auto
 
 test-unit:  ## Run unit tests only
 	poetry run pytest tests/unit -m unit
@@ -58,8 +58,8 @@ test-e2e:  ## Run end-to-end tests only
 	poetry run pytest tests/e2e -m e2e
 
 coverage:  ## Generate HTML and terminal coverage report
-	poetry run pytest --cov=reveille --cov-report=term-missing --cov-report=html
-	@echo "HTML coverage report: htmlcov/index.html"
+    poetry run pytest -n auto --cov=reveille --cov-report=term-missing --cov-report=html
+    @echo "HTML coverage report: htmlcov/index.html"
 
 # ------------------------------------------------------------------
 # CI

--- a/poetry.lock
+++ b/poetry.lock
@@ -964,6 +964,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -1324,4 +1338,4 @@ python-discovery = ">=1.2.2"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5c589a983f4d9416fb3302b75d864261cd08ca1902ca7520050da90672e4729b"
+content-hash = "860f5ab2100760c705e208077e218d9af1a2d5bf8aa530df68fd429b9ace7629"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ optional = false
 pytest = "^8.0.0"
 pytest-cov = "^5.0.0"
 pytest-xdist = "^3.5.0"
+pytest-timeout = "^2.3.0"
 
 # Type Checking
 mypy = "^1.8.0"
@@ -222,14 +223,8 @@ addopts = [
     "--verbose",
     "--strict-markers",
     "--strict-config",
-    "-n",
-    "auto",
-    "--cov=reveille",
-    "--cov-report=term-missing",
-    "--cov-report=html",
-    "--cov-report=xml",
-    "--no-cov-on-fail",
 ]
+timeout = 120
 markers = [
     "unit: Unit tests -- no I/O, no filesystem, no subprocess",
     "integration: Integration tests -- real Git repositories via fixtures",
@@ -252,7 +247,7 @@ filterwarnings = [
 source = ["src/reveille"]
 branch = true
 parallel = true
-data_file = ".coverage_data/.coverage"
+data_file = ".coverage"
 omit = [
     "*/tests/*",
     "*/__init__.py",

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -209,8 +209,16 @@ class TestGenerateCommand:
     def test_output_file_has_no_external_script_tags(
         self, default_report_content: str
     ) -> None:
-        assert 'src="http' not in default_report_content
-        assert "src='http" not in default_report_content
+        import re
+
+        external_tags = re.findall(
+            r'<script[^>]+src=["\']https?://',
+            default_report_content,
+        )
+        assert external_tags == [], (
+            f"Report contains {len(external_tags)} external script reference(s): "
+            f"{external_tags}"
+        )
 
     # -- Distinct invocations (different flags, cannot share) --
 


### PR DESCRIPTION
## Summary

The e2e test `test_output_file_has_no_external_script_tags` was failing
and blocking the CI pipeline (cancelled after 365 minutes on GitHub
Actions; timed out at 120 seconds locally after the timeout guard was
introduced in the preceding configuration commit).

## Root Cause

Two compounding defects shared a single cause.

**Wrong assertion.** The test checked whether the bare string `src="http"`
appears anywhere in the report HTML. The 3.5 MB embedded Plotly JS bundle
contains this character sequence in its own minified source. The assertion
was therefore always false, and the test was always failing — it had never
correctly validated the output contract.

**Difflib hang on assertion failure.** When pytest renders a failed
`assert X not in Y` expression, it passes both operands to
`difflib.SequenceMatcher.find_longest_match()` to produce a contextual
diff. That algorithm is O(n²) in the length of the inputs. With Y being
a 4.5 MB string, it does not complete within any reasonable timeout.
The hang was a downstream consequence of the wrong assertion, not an
independent bug.

## Fix

`test_output_file_has_no_external_script_tags` is rewritten to use a
targeted regex that matches only `<script>` elements carrying an `src`
attribute pointing to an external URL — which is the actual output
contract being validated. The Plotly bundle contents are structurally
irrelevant to this check.

If the assertion fails, the failure message contains only the list of
offending tags. The full HTML content is never passed to difflib.

## Changes

**`tests/e2e/test_cli.py`** — `TestGenerateCommand`

Replaces two bare substring assertions with a single `re.findall` call
against the pattern `<script[^>]+src=["']https?://`.

## Testing

```bash
poetry run pytest tests/e2e/test_cli.py -v
poetry run pytest -n auto --timeout=120
```

Expected result: 135 passed, 0 failed. Suite completes in under two
minutes.

## Notes

This PR also carries the configuration changes introduced while
diagnosing the hang: `addopts` in `pyproject.toml` stripped of
runtime flags (`-n auto`, coverage), `timeout = 120` added, coverage
`data_file` path corrected, and Makefile and CI workflow updated to
supply parallelism and coverage flags explicitly at the call site.