### PR TITLE
fix(renderer): force categorical axis on all heatmap builders to prev…

### DIFF
--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -306,7 +306,8 @@ def _build_heatmap_weekly(commits: list[Commit]) -> str:
     num_weeks = max(week_indices) + 1
     z = [[cell.get((w, day), 0) for w in range(num_weeks)] for day in range(7)]
     week_labels = [
-        (base_week + datetime.timedelta(weeks=w)).isoformat() for w in range(num_weeks)
+        (base_week + datetime.timedelta(weeks=w)).strftime("%b %d")
+        for w in range(num_weeks)
     ]
     day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
@@ -321,7 +322,17 @@ def _build_heatmap_weekly(commits: list[Commit]) -> str:
         )
     )
     layout = _base_layout()
-    layout["yaxis"] = {"autorange": "reversed", "gridcolor": "#30363d"}
+    layout["xaxis"] = {
+        "type": "category",
+        "gridcolor": "#30363d",
+        "linecolor": "#30363d",
+    }
+    layout["yaxis"] = {
+        "autorange": "reversed",
+        "gridcolor": "#30363d",
+        "scaleanchor": "x",
+        "constrain": "domain",
+    }
     fig.update_layout(**layout, height=260)
     return _to_json(fig)
 
@@ -365,7 +376,17 @@ def _build_heatmap_monthly(commits: list[Commit]) -> str:
         )
     )
     layout = _base_layout()
-    layout["yaxis"] = {"autorange": "reversed", "gridcolor": "#30363d"}
+    layout["xaxis"] = {
+        "type": "category",
+        "gridcolor": "#30363d",
+        "linecolor": "#30363d",
+    }
+    layout["yaxis"] = {
+        "autorange": "reversed",
+        "gridcolor": "#30363d",
+        "scaleanchor": "x",
+        "constrain": "domain",
+    }
     fig.update_layout(**layout, height=260)
     return _to_json(fig)
 
@@ -422,7 +443,17 @@ def _build_heatmap_yearly(commits: list[Commit]) -> str:
         )
     )
     layout = _base_layout()
-    layout["yaxis"] = {"autorange": "reversed", "gridcolor": "#30363d"}
+    layout["xaxis"] = {
+        "type": "category",
+        "gridcolor": "#30363d",
+        "linecolor": "#30363d",
+    }
+    layout["yaxis"] = {
+        "autorange": "reversed",
+        "gridcolor": "#30363d",
+        "scaleanchor": "x",
+        "constrain": "domain",
+    }
     fig.update_layout(**layout, height=340)
     return _to_json(fig)
 

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -311,6 +311,30 @@ class TestBuildHeatmapChart:
         commits = [_make_commit(datetime.date(2024, 1, 8))]
         assert _is_valid_chart_json(_build_heatmap_chart(commits, "yearly"))
 
+    def test_weekly_xaxis_type_is_category(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 1, 8)),
+            _make_commit(datetime.date(2024, 1, 15)),
+        ]
+        result = json.loads(_build_heatmap_chart(commits, "weekly"))
+        assert result["layout"]["xaxis"]["type"] == "category"
+
+    def test_monthly_xaxis_type_is_category(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 1, 8)),
+            _make_commit(datetime.date(2024, 2, 5)),
+        ]
+        result = json.loads(_build_heatmap_chart(commits, "monthly"))
+        assert result["layout"]["xaxis"]["type"] == "category"
+
+    def test_yearly_xaxis_type_is_category(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2023, 6, 1)),
+            _make_commit(datetime.date(2024, 3, 15)),
+        ]
+        result = json.loads(_build_heatmap_chart(commits, "yearly"))
+        assert result["layout"]["xaxis"]["type"] == "category"
+
 
 # ------------------------------------------------------------------
 # _build_contributor_commits_chart


### PR DESCRIPTION
…ent date coercion

Plotly silently coerces string labels that resemble ISO 8601 dates to a continuous date axis. Labels such as '2026-01' and '2026-01-05' are treated as timestamps, causing the axis tick algorithm to produce labels like 'Dec 28 2025' and 'Jan 11' instead of the intended month or week buckets. Confirmed against a real repository with 325 commits.

All three heatmap builders now set xaxis.type to 'category', preventing coercion at the layout level. yaxis gains scaleanchor and constrain to maintain square cell geometry regardless of column count.

The weekly builder's week_labels list is changed from .isoformat() to .strftime('%b %d'), eliminating coercible ISO strings at the data level and improving legibility at compressed widths.

Three new assertions added to TestBuildHeatmapChart verifying that xaxis.type equals 'category' in the parsed layout for all three granularities.