### PR TITLE
chore(misc-cleanup): correct pre-commit ruff revision, consolidate CH…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,9 @@ repos:
   # Runs before black so that any auto-fixes are subsequently formatted.
   # ------------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5
+    rev: v0.15.7
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
 
   # ------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,73 @@
 # Changelog
 
 All notable changes to Reveille are documented in this file.
-
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] — 2026-04-30
+
 ### Added
+
 - Project README covering installation, quickstart, CLI reference,
   contributor ranking system, configuration schema, and contribution guidelines.
-- pyproject.toml with full Poetry configuration and tool settings
+- Comprehensive User Guide at `docs/USER_GUIDE.md` covering every CLI flag,
+  every TOML key, the ranking algorithm in plain language, report interpretation
+  guidance, and practical patterns for common use cases.
+- `pyproject.toml` with full Poetry configuration and tool settings
   for ruff, mypy, pytest, and coverage.
-- poetry.lock for reproducible dependency resolution.
-- .gitignore scoped to a Python CLI project using Poetry.
-- Domain models: Commit, ContributorStats, RankedContributor,
-  RepositoryMetadata, ReportData.
-- Domain exception hierarchy under reveille.exceptions.
-- Configuration models: ReportConfig, RankingWeights with validation.
-- Ranking engine interface with tier boundary definitions.
-- GitReader adapter interface.
-- Renderer adapter interface.
-- Typer CLI with generate, validate, and version commands.
-- Pytest fixture stubs in tests/conftest.py.
-- GitHub Actions CI workflow (lint, typecheck, test in parallel).
+- `poetry.lock` for reproducible dependency resolution.
+- `.gitignore` scoped to a Python CLI project using Poetry.
+- Domain models: `Commit`, `ContributorStats`, `RankedContributor`,
+  `RepositoryMetadata`, `ReportData`.
+- Domain exception hierarchy under `reveille.exceptions`.
+- Configuration models: `ReportConfig`, `RankingWeights` with validation.
+- `GitReader` adapter with full integration test coverage.
+- Ranking engine with weighted composite scoring and tier assignment.
+- `Renderer` adapter, Jinja2 HTML template, and report service.
+- Typer CLI with `generate`, `validate`, and `version` commands.
+- TOML configuration file support with full CLI flag precedence.
+- Dark mode toggle with localStorage persistence.
+- Heatmap granularity control: `weekly`, `monthly`, `yearly` views,
+  exposed as `--heatmap-granularity` CLI flag and TOML key.
+- Commit share and lines share donut charts.
+- Tier badges in the contributor ranking table with solid fill for
+  tiers III–VII and outlined style for tiers I–II.
+- Score bar with gradient fill and comma-formatted numeric columns.
+- `pytest-timeout` added to the development dependency group with a
+  120-second global ceiling.
+- GitHub Actions CI workflow running lint, typecheck, and test jobs in
+  parallel across Python 3.11 and 3.12.
 - Makefile with standard development targets.
+- Pre-commit configuration with ruff, black, and mypy hooks.
 - MIT licence.
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/HEAD
-
 ### Changed
+
 - Tier designation strings updated to a consistent NATO-aligned military
   rank progression: Private, Corporal, Sergeant, Lieutenant, Captain,
-  Major, Commander. The previous set mixed military and professional
-  title conventions inconsistently. Commander is retained at tier VII.
+  Major, Commander. The previous set mixed military terminology with
+  professional titles inconsistently. Commander is retained at tier VII.
+- Heatmap x-axis coercion fixed: all three heatmap builders now set
+  `xaxis.type` to `"category"`, preventing Plotly from silently treating
+  ISO 8601 label strings as timestamps. The weekly builder's column
+  labels changed from `.isoformat()` to `.strftime("%b %d")`.
+- `addopts` in `pyproject.toml` stripped of runtime flags (`-n auto`,
+  coverage instrumentation). Parallelism and coverage are now supplied
+  explicitly at the call site in the Makefile and CI workflow.
+- Coverage `data_file` path corrected from `.coverage_data/.coverage`
+  to `.coverage`, eliminating a worker deadlock under `pytest-xdist`.
+- `test_output_file_has_no_external_script_tags` rewritten to use a
+  targeted regex against `<script[^>]+src=["']https?://` rather than a
+  bare substring check, eliminating a false positive against the embedded
+  Plotly bundle and a `difflib` O(n²) hang on assertion failure.
+- Module-level `_PLOTLY_JS_BUNDLE` constant introduced in the renderer,
+  replacing a per-call `plotly.offline.get_plotlyjs()` invocation.
+  Reduces end-to-end test suite runtime from approximately 40 minutes
+  to under two minutes.
+- Pre-commit ruff hook revision updated from `v0.14.5` to `v0.15.7`.
+  Hook identifier updated from the legacy `ruff` alias to `ruff-check`.
+
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.1.0

--- a/src/reveille/exceptions.py
+++ b/src/reveille/exceptions.py
@@ -45,8 +45,8 @@ class RenderError(RevelleError):
 
 
 class OutputPathError(RenderError):
-    """Raised when the specified output path cannot be written to.
+    """Raised when the specified output path cannot be written.
 
-    Caused either by the parent directory not existing or by
-    insufficient filesystem permissions.
+    Caused by the parent directory not existing or by insufficient
+    filesystem permissions.
     """


### PR DESCRIPTION
…ANGELOG, tighten exceptions docstring

Update ruff-pre-commit revision from the non-existent v0.14.5 to the current published release v0.15.7. Update hook id from the deprecated legacy alias 'ruff' to the current 'ruff-check'.

Promote all [Unreleased] CHANGELOG entries into a versioned [0.1.0] section dated 2026-04-30. Consolidates additions and changes from all twelve merged PRs. Adds a fresh empty [Unreleased] section for future work. Adds correct comparison URL for the 0.1.0 tag.

Tighten phrasing in OutputPathError docstring.