### PR TITLE
fix(renderer): force categorical axis on timeline chart to prevent da…

### DIFF
--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -243,8 +243,15 @@ def _build_timeline_chart(commits: list[Commit]) -> str:
             hovertemplate="Week of %{x}<br>Commits: %{y}<extra></extra>",
         )
     )
+    layout = _base_layout()
+    layout["xaxis"] = {
+        "type": "category",
+        "gridcolor": "#e2e8f0",
+        "linecolor": "#d1d9e0",
+        "tickangle": -45,
+    }
     fig.update_layout(
-        **_base_layout(),
+        **layout,
         xaxis_title="Week",
         yaxis_title="Commits",
         height=280,

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -228,6 +228,14 @@ class TestBuildTimelineChart:
         assert "paper_bgcolor" not in layout
         assert "plot_bgcolor" not in layout
 
+    def test_xaxis_type_is_category(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 1, 8)),
+            _make_commit(datetime.date(2024, 1, 15)),
+        ]
+        result = json.loads(_build_timeline_chart(commits))
+        assert result["layout"]["xaxis"]["type"] == "category"
+
 
 # ------------------------------------------------------------------
 # _build_heatmap_chart — dispatch and granularity variants


### PR DESCRIPTION
…te coercion

Plotly was coercing ISO 8601 week-start date strings on the timeline x-axis to timestamps, producing tick labels such as '23:59:59.999 Apr 26, 2026' instead of clean week labels.

Applies the same categorical axis fix used in PR #10 for the heatmap builders. Sets xaxis.type to 'category' and tickangle to -45 for readability at compressed widths.

One new assertion added to TestBuildTimelineChart verifying that xaxis.type equals 'category' in the parsed layout.