### PR TITLE
fix(readme): replace relative docs link with absolute GitHub URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-04-30
+
+### Fixed
+
+- Documentation link in README now points to the absolute GitHub URL for
+  `docs/USER_GUIDE.md`, resolving a broken relative path on the PyPI project page.
+- Makefile recipe indentation corrected from spaces to tabs, resolving
+  `missing separator` errors on strict Make implementations (PR #16).
+
 ## [0.1.0] — 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ CLI flags always take precedence over configuration file values. The configurati
 
 ## Documentation
 
-A full operational reference is available at [docs/USER_GUIDE.md](docs/USER_GUIDE.md).
+A full operational reference is available at [docs/USER_GUIDE.md](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/USER_GUIDE.md).
 It covers every CLI flag and its interaction effects, every TOML key with
 annotated examples, the ranking algorithm in plain language, how to interpret
 each section of the generated report, and practical patterns for common use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.1.0"
+version = "0.1.1"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Varaprasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "MIT"

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -4,7 +4,7 @@ A CLI tool that generates self-contained HTML performance reports
 from local Git repositories.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "Varaprasad Chilakanti"
 __email__ = "varaprasadchilakanti@gmail.com"
 __licence__ = "MIT"


### PR DESCRIPTION
The relative path to docs/USER_GUIDE.md does not resolve on the PyPI project page. Replaced with the absolute GitHub URL. Version bumped to 0.1.1.