### PR TITLE
fix(renderer): unify daily heatmap dispatch and narrow exception catch in __init__

### DIFF
--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -28,7 +28,13 @@ from typing import Any, Literal, TypeAlias
 
 import plotly.graph_objects as go
 import plotly.offline
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import (
+    Environment,
+    PackageLoader,
+    TemplateNotFound,
+    TemplatesNotFound,
+    select_autoescape,
+)
 
 from reveille.domain.models import Commit, RankedContributor, ReportData
 from reveille.exceptions import OutputPathError, RenderError
@@ -79,7 +85,7 @@ class Renderer:
                 autoescape=select_autoescape(["html", "j2"]),
             )
             self._template = self._env.get_template("report.html.j2")
-        except Exception as exc:
+        except (TemplateNotFound, TemplatesNotFound, OSError) as exc:
             raise RenderError(
                 "Failed to load the report template. "
                 "Verify the package was installed correctly and that "

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -194,8 +194,8 @@ class Renderer:
         """
         return {
             "timeline": _build_timeline_chart(data.commits),
-            "heatmap_daily": _build_heatmap_daily(
-                data.commits, data.metadata.analysis_until
+            "heatmap_daily": _build_heatmap_chart(
+                data.commits, "daily", window_end=data.metadata.analysis_until
             ),
             "heatmap_weekly": _build_heatmap_chart(data.commits, "weekly"),
             "heatmap_monthly": _build_heatmap_chart(data.commits, "monthly"),

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -437,13 +437,14 @@ class TestGenerateCommand:
         )
         assert result.exit_code == 1
 
-    def test_output_embeds_all_three_heatmap_specs(
+    def test_output_embeds_all_four_heatmap_specs(
         self, default_report_content: str
     ) -> None:
         """All three heatmap granularity specs are present in the output."""
         assert 'id="spec-heatmap-weekly"' in default_report_content
         assert 'id="spec-heatmap-monthly"' in default_report_content
         assert 'id="spec-heatmap-yearly"' in default_report_content
+        assert 'id="spec-heatmap-daily"' in default_report_content
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Closes two findings from the v0.2.0 codebase audit (Module 2:
reveille.adapters.renderer). Also closes the test coverage gap
identified in Module 9 (FINDING-9), which is directly related to
FINDING-3 and travels cleanly in this PR.

## FINDING-3 — Dual daily heatmap generation paths (P1)

`Renderer._build_charts` was calling `_build_heatmap_daily` directly,
passing `data.metadata.analysis_until` as the window anchor. The dispatch
function `_build_heatmap_chart` handled the `"daily"` case separately,
falling back to `max(commit dates)` when `window_end` was not provided.
These two paths produced different charts whenever `analysis_until`
differed from the latest commit date — for example, when `--until` was
set to a future date to establish an inclusive analysis window.

The direct call is replaced with `_build_heatmap_chart(data.commits,
"daily", window_end=data.metadata.analysis_until)`, routing all four
granularities through the single dispatch function. The runtime behaviour
is identical under the common case; the divergence is eliminated.

## FINDING-9 — Missing daily heatmap spec assertion (P1)

`test_output_embeds_all_three_heatmap_specs` was asserting the presence
of the weekly, monthly, and yearly specs but not the daily spec, which
was added in PR #23. A regression removing `id="spec-heatmap-daily"`
from the template would have been undetected. The assertion is added and
the method is renamed to `test_output_embeds_all_four_heatmap_specs`.

## FINDING-4 — Bare Exception catch in Renderer.__init__ (P2)

The `try/except Exception` block wrapping `PackageLoader` construction
and `get_template` was masking the distinction between a missing template
file (`TemplateNotFound`), a missing template package (`TemplatesNotFound`),
and a filesystem access failure (`OSError`). The catch is narrowed to
those three specific types. Any other unexpected exception now propagates
without being silently wrapped into a `RenderError`.

## Verification

- `mypy src/reveille/adapters/renderer.py` — clean
- `ruff check src/reveille/adapters/renderer.py` — clean
- `pytest tests/unit/adapters/test_renderer.py tests/e2e/test_cli.py -v` — 88 passed