### PR TITLE
fix(git-reader): remove unused window_start and window_end from aggregate_contributor_stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   a broken relative path on the PyPI project page.
 - MIT Licence link in README replaced with absolute GitHub URL, resolving
   a broken relative path on the PyPI project page.
+- Contributor ranking now correctly handles tied composite scores. Previously,
+  contributors with identical composite scores all received the lowest percentile
+  in their group, causing equally active contributors in small teams to be
+  assigned the Private designation regardless of their output. Rank computation
+  now uses `bisect.bisect_left`, which applies lower-bound percentile semantics
+  and is O(log n) per lookup rather than O(n).
+- Daily heatmap chart generation unified through the `_build_heatmap_chart`
+  dispatch function. The embedded daily spec and the client-side toggle path
+  previously used different `window_end` anchors when `--until` extended beyond
+  the latest commit date, producing silently divergent charts. Both paths now
+  use `analysis_until` as the anchor.
+- `assign_tier` unreachable fallback removed. The function previously contained
+  a final return of the undocumented designation "Recruit" that could never be
+  reached. An `AssertionError` is now raised in its place to make any future
+  `_TIER_BOUNDARIES` misconfiguration immediately visible.
+- Exception handling in `Renderer.__init__` narrowed from bare `Exception` to
+  `TemplateNotFound`, `TemplatesNotFound`, and `OSError`. Unexpected exceptions
+  now propagate without being wrapped, preserving diagnostic information at the
+  CLI boundary.
+- `GitReader.aggregate_contributor_stats` signature corrected: `window_start`
+  and `window_end` parameters documented as "stored on the returned stats" were
+  never used in the function body. Both parameters have been removed and all
+  call sites updated.
 
 ## [0.1.1] — 2026-04-30
 

--- a/src/reveille/adapters/git_reader.py
+++ b/src/reveille/adapters/git_reader.py
@@ -153,8 +153,6 @@ class GitReader:
         self,
         commits: list[Commit],
         min_commits: int,
-        window_start: datetime.date,
-        window_end: datetime.date,
     ) -> list[ContributorStats]:
         """Aggregate raw commits into per-contributor statistics.
 
@@ -166,9 +164,6 @@ class GitReader:
             commits: Raw commit list returned by read_commits.
             min_commits: Exclude contributors with fewer than this many
                 commits in the analysis window.
-            window_start: Start of the analysis window. Stored on the
-                returned stats for use by the ranking engine.
-            window_end: End of the analysis window.
 
         Returns:
             A list of ContributorStats sorted by commit count descending.

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -61,8 +61,6 @@ def generate_report(config: ReportConfig) -> Path:
     contributor_stats = reader.aggregate_contributor_stats(
         commits=commits,
         min_commits=config.min_commits,
-        window_start=window_start,
-        window_end=window_end,
     )
 
     ranked_contributors: list[RankedContributor]

--- a/tests/integration/test_git_reader.py
+++ b/tests/integration/test_git_reader.py
@@ -276,8 +276,6 @@ class TestAggregateContributorStats:
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
-            window_start=datetime.date(2024, 3, 1),
-            window_end=datetime.date(2024, 4, 30),
         )
         assert len(stats) == 2
 
@@ -289,8 +287,6 @@ class TestAggregateContributorStats:
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
-            window_start=datetime.date(2024, 3, 1),
-            window_end=datetime.date(2024, 4, 30),
         )
         alice = next(s for s in stats if s.email == "alice@example.com")
         assert alice.commit_count == 3
@@ -303,8 +299,6 @@ class TestAggregateContributorStats:
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
-            window_start=datetime.date(2024, 3, 1),
-            window_end=datetime.date(2024, 4, 30),
         )
         counts = [s.commit_count for s in stats]
         assert counts == sorted(counts, reverse=True)
@@ -320,8 +314,6 @@ class TestAggregateContributorStats:
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=3,
-            window_start=datetime.date(2024, 3, 1),
-            window_end=datetime.date(2024, 4, 30),
         )
         assert len(stats) == 1
         assert stats[0].email == "alice@example.com"
@@ -336,8 +328,6 @@ class TestAggregateContributorStats:
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
-            window_start=datetime.date(2024, 3, 1),
-            window_end=datetime.date(2024, 4, 30),
         )
         alice = next(s for s in stats if s.email == "alice@example.com")
         # Alice committed on 3 distinct calendar dates.

--- a/tests/unit/services/test_report.py
+++ b/tests/unit/services/test_report.py
@@ -250,7 +250,7 @@ class TestGenerateReport:
 
             generate_report(minimal_config)
 
-        call_kwargs = reader_instance.aggregate_contributor_stats.call_args
+        call_kwargs = mock_rank.call_args
         assert call_kwargs.kwargs["window_start"] == datetime.date(2024, 1, 1)
 
     def test_renderer_receives_commits_in_report_data(


### PR DESCRIPTION
Closes FINDING-5 from the v0.2.0 codebase audit (Module 3:
reveille.adapters.git_reader). Also records all audit corrections
from PRs #25 and #26 in the CHANGELOG.

## FINDING-5 — Dead parameters in aggregate_contributor_stats (P1)

`aggregate_contributor_stats` accepted `window_start` and `window_end`
as parameters. The docstring stated these were "stored on the returned
stats for use by the ranking engine." Neither parameter appeared anywhere
in the function body, and `ContributorStats` has no such fields. The
documentation was false.

The ranking engine correctly receives `window_start` and `window_end`
directly from the service layer — the actual runtime behaviour was
correct throughout. The issue was that any engineer reading the function
signature would form an incorrect mental model of where window bounds
are passed and consumed.

Both parameters are removed from the signature and all call sites:
`generate_report` in `services/report.py`, five methods in
`tests/integration/test_git_reader.py`, and the unit test assertion
in `tests/unit/services/test_report.py` is redirected to `mock_rank`,
which is the function that actually consumes `window_start`.

## CHANGELOG

Adds entries to `[Unreleased] ### Fixed` for all five audit corrections
applied across PRs #25, #26, and this PR.

## Verification

- `mypy src/reveille/adapters/git_reader.py src/reveille/services/report.py` — clean
- `ruff check` — clean
- `pytest -n auto` — 168 passed