### PR TITLE
fix(cli): use None sentinel for min_commits to enforce documented CLI precedence over config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   and `window_end` parameters documented as "stored on the returned stats" were
   never used in the function body. Both parameters have been removed and all
   call sites updated.
+- `--min-commits 1` on the CLI now correctly overrides a higher `min_commits`
+  value set in a `reveille.toml` configuration file. Previously, the value
+  `1` was treated as equivalent to "flag not provided," causing the config
+  file value to win silently and violating the documented CLI precedence rule.
+  The parameter now uses `None` as its sentinel, allowing explicit `1` to be
+  distinguished from the absence of the flag.
+
 
 ## [0.1.1] — 2026-04-30
 
@@ -68,6 +75,7 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   `docs/USER_GUIDE.md`, resolving a broken relative path on the PyPI project page.
 - Makefile recipe indentation corrected from spaces to tabs, resolving
   `missing separator` errors on strict Make implementations (PR #16).
+
 
 ## [0.1.0] — 2026-04-30
 

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -80,7 +80,7 @@ def _merge_cli_flags(
     branch: str | None,
     title: str | None,
     exclude_author: list[str] | None,
-    min_commits: int,
+    min_commits: int | None,
     no_ranking: bool,
     heatmap_granularity: str | None,
 ) -> dict[str, object]:
@@ -123,7 +123,7 @@ def _merge_cli_flags(
         merged["title"] = title
     if exclude_author:
         merged["exclude_authors"] = exclude_author
-    if min_commits != 1:
+    if min_commits is not None:
         merged["min_commits"] = min_commits
     if no_ranking:
         merged["ranking_enabled"] = False
@@ -169,11 +169,11 @@ def generate(
         ),
     ] = None,
     min_commits: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--min-commits", help="Exclude contributors below this commit threshold."
         ),
-    ] = 1,
+    ] = None,
     title: Annotated[
         str | None,
         typer.Option("--title", help="Override the report title in the HTML output."),

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -398,6 +398,42 @@ class TestGenerateCommand:
         assert "CLI Title" in content
         assert "Config Title" not in content
 
+    def test_min_commits_cli_flag_overrides_config_file_value(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """--min-commits 1 takes precedence over min_commits = 2 in a config file.
+
+        The e2e fixture contains Bob with one commit. A config file with
+        min_commits = 2 would exclude him. Passing --min-commits 1 on the
+        CLI must override the config value and include him in the output.
+        """
+        base = tmp_path_factory.mktemp("min_commits_override")
+        output = base / "report.html"
+        config_file = base / "reveille.toml"
+        config_file.write_text(
+            "[filters]\nmin_commits = 2\n",
+            encoding="utf-8",
+        )
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(output),
+                "--config",
+                str(config_file),
+                "--min-commits",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0
+        content = output.read_text(encoding="utf-8")
+        assert "Bob" in content
+
     def test_nonexistent_config_file_exits_nonzero(
         self,
         e2e_repo: Path,


### PR DESCRIPTION
Closes FINDING-6 from the v0.2.0 codebase audit (Module 4: reveille.cli).

## Problem

The `--min-commits` flag in the `generate` command used `1` as both its
default value and its "not provided" sentinel. The merge logic in
`_merge_cli_flags` guarded the assignment with `if min_commits != 1`,
which meant that passing `--min-commits 1` explicitly was indistinguishable
from omitting the flag entirely. If a `reveille.toml` contained
`min_commits = 5`, invoking `reveille generate --min-commits 1 --config
reveille.toml` would silently retain the config file value of 5, violating
the documented rule that CLI flags always take precedence over configuration
file values.

## Fix

The `min_commits` parameter in the `generate` command is changed from
`int` with a default of `1` to `int | None` with a default of `None`.
The guard is updated to `if min_commits is not None`, which applies the
CLI value unconditionally whenever the flag is present. When the flag is
absent, `None` flows through to `ReportConfig`, where Pydantic's field
default of `1` takes effect. This correctly separates "not provided" from
"explicitly provided as 1."

## Verification

A targeted e2e test is added: a config file sets `min_commits = 2`, which
would exclude Bob (one commit in the fixture repository). Passing
`--min-commits 1` on the CLI must override this and include Bob in the
output. The test confirms that behaviour directly.

- `mypy src/reveille/cli.py` — clean
- `ruff check src/reveille/cli.py` — clean
- `pytest -n auto` — 169 passed