### PR TITLE
fix(config): consolidate HeatmapGranularity to domain layer and relax RankingWeights tolerance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   file value to win silently and violating the documented CLI precedence rule.
   The parameter now uses `None` as its sentinel, allowing explicit `1` to be
   distinguished from the absence of the flag.
+- `HeatmapGranularity` type alias consolidated to `reveille.domain.models`,
+  eliminating a triplicate definition across `config.py`, `renderer.py`, and
+  the TOML validation block. Both layers now import the canonical definition
+  from the domain; the validation tuple is derived via `get_args` so it
+  stays in sync automatically. The error message for invalid TOML values now
+  lists accepted options derived from the type.
 
 
 ## [0.1.1] — 2026-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   from the domain; the validation tuple is derived via `get_args` so it
   stays in sync automatically. The error message for invalid TOML values now
   lists accepted options derived from the type.
+- `RankingWeights` sum validation tolerance relaxed from `1e-9` to `1e-6`.
+  The previous threshold was unnecessarily strict for user-supplied decimal
+  weights, where IEEE 754 rounding could plausibly produce deviations
+  approaching `1e-9` despite representing an exact decimal sum of `1.0`.
 
 
 ## [0.1.1] — 2026-04-30

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -24,7 +24,7 @@ import datetime
 import json
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import Any
 
 import plotly.graph_objects as go
 import plotly.offline
@@ -36,10 +36,13 @@ from jinja2 import (
     select_autoescape,
 )
 
-from reveille.domain.models import Commit, RankedContributor, ReportData
+from reveille.domain.models import (
+    Commit,
+    HeatmapGranularity,
+    RankedContributor,
+    ReportData,
+)
 from reveille.exceptions import OutputPathError, RenderError
-
-HeatmapGranularity: TypeAlias = Literal["weekly", "monthly", "yearly", "daily"]
 
 # Maximum individual slices in a pie chart. Contributors beyond this
 # threshold are aggregated into a single "Other Contributors" slice

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -42,7 +42,7 @@ class RankingWeights(BaseModel):
             ValueError: If the sum deviates from 1.0 by more than 1e-9.
         """
         total = self.commits + self.lines + self.consistency + self.recency
-        if abs(total - 1.0) > 1e-9:
+        if abs(total - 1.0) > 1e-6:
             raise ValueError(
                 f"Ranking weights must sum to 1.0, got {total:.6f}. "
                 "Adjust weights so that commits + lines + consistency + recency = 1.0."

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import datetime
 import tomllib
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, get_args
 
 from pydantic import BaseModel, Field, model_validator
 
+from reveille.domain.models import HeatmapGranularity
 from reveille.exceptions import ConfigurationError
 
 
@@ -70,7 +71,7 @@ class ReportConfig(BaseModel):
     min_commits: int = Field(default=1, ge=1)
     ranking_enabled: bool = Field(default=True)
     ranking_weights: RankingWeights = Field(default_factory=RankingWeights)
-    heatmap_granularity: Literal["weekly", "monthly", "yearly", "daily"] = Field(
+    heatmap_granularity: HeatmapGranularity = Field(
         default="monthly",
         description=(
             "Resolution of the commit activity heatmap. "
@@ -166,10 +167,10 @@ def _parse_report_section(report: dict[str, Any]) -> dict[str, Any]:
                 ) from exc
     if "heatmap_granularity" in report:
         val = str(report["heatmap_granularity"])
-        if val not in ("weekly", "monthly", "yearly", "daily"):
+        if val not in get_args(HeatmapGranularity):
             raise ConfigurationError(
                 f"Invalid heatmap_granularity '{val}' in configuration file. "
-                "Must be one of: daily, weekly, monthly, yearly."
+                f"Must be one of: {', '.join(get_args(HeatmapGranularity))}."
             )
         kwargs["heatmap_granularity"] = val
     return kwargs

--- a/src/reveille/domain/models.py
+++ b/src/reveille/domain/models.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+HeatmapGranularity: TypeAlias = Literal["daily", "weekly", "monthly", "yearly"]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Closes FINDING-7 and FINDING-8 from the v0.2.0 codebase audit
(Module 5: reveille.config). Both findings are P2.

## FINDING-7 — HeatmapGranularity triplicate definition (P2)

The valid granularity values were defined independently in three
locations: as a Literal field type in `ReportConfig`, as a TypeAlias
in `renderer.py`, and as an inline validation tuple in
`_parse_report_section`. This arrangement had already produced one
escaped defect — the missing `"daily"` value in the TOML template,
corrected in PR #24 — because adding a new granularity required
manually updating all three sites.

`HeatmapGranularity` is now defined once as a TypeAlias in
`reveille.domain.models`, the layer accessible to both the config
and adapter layers without violating the dependency rule. Both
`config.py` and `renderer.py` import it from there. The validation
tuple in `_parse_report_section` is replaced with `get_args(HeatmapGranularity)`,
so the accepted values list is derived from the type itself and the
error message stays accurate automatically if the Literal is extended.

## FINDING-8 — RankingWeights sum tolerance too tight (P2)

The validator enforced the sum-to-one constraint with a tolerance of
`1e-9`. IEEE 754 double-precision arithmetic can accumulate rounding
errors on the order of `1e-15` to `1e-16` for typical decimal inputs,
so the default weights are unaffected. However, user-supplied weights
involving thirds or other repeating decimals could plausibly produce
deviations approaching `1e-9`, causing a spurious validation failure
despite the intended sum being exactly `1.0`. The tolerance is
relaxed to `1e-6`, which is the conventional threshold for this
category of floating-point validation.

## Verification

- `mypy` across all three modified source files — clean
- `ruff check` across all three modified source files — clean
- `pytest -n auto` — 169 passed