### PR TITLE
docs(v0.2.0): update README and User Guide for reveille init, daily heatmap, and granularity toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,51 +6,50 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
-
 ### Added
 
-- Daily heatmap granularity. `_build_heatmap_daily` produces a GitHub-style
-  52-column layout with one cell per calendar day. The rolling window defaults
-  to 365 days back from the analysis window end to prevent excessive chart
-  width. Added as a fourth granularity toggle button alongside weekly, monthly,
-  and yearly.
-- Client-side heatmap granularity toggle. All three heatmap specs (weekly,
-  monthly, yearly) are now embedded in the HTML output. Three toggle buttons
-  allow switching between granularities via Plotly.react() without a page
-  reload. The --heatmap-granularity flag controls the default view on open.
 - `reveille init` command that writes a fully annotated `reveille.toml`
   to the current directory with all configuration keys present, documented
   inline, and set to their defaults. Eliminates the need to consult
   documentation when beginning to customise the tool.
-- `--force` flag for `reveille init` to overwrite an existing configuration
-  file without prompting.
 - `--output` flag for `reveille init` to write the configuration file to
   a non-default path.
+- `--force` flag for `reveille init` to overwrite an existing configuration
+  file without prompting.
+- Client-side heatmap granularity toggle. All four heatmap specs (daily,
+  weekly, monthly, yearly) are embedded in the HTML output. Toggle buttons
+  allow switching between granularities via `Plotly.react()` without a page
+  reload. The `--heatmap-granularity` flag controls the default view on open.
+- Daily heatmap granularity. `_build_heatmap_daily` produces a GitHub-style
+  layout with one cell per calendar day. The rolling window defaults to 365
+  days back from the analysis window end to prevent excessive chart width.
+  Available as the fourth granularity option alongside weekly, monthly,
+  and yearly.
 
 ### Fixed
 
-- `reveille init` template corrected to include `"daily"` as an accepted
-  `heatmap_granularity` value with inline usage guidance, consistent with
-  the other three granularity options.
 - CHANGELOG link in README replaced with absolute GitHub URL, resolving
   a broken relative path on the PyPI project page.
 - MIT Licence link in README replaced with absolute GitHub URL, resolving
   a broken relative path on the PyPI project page.
+- `reveille init` template corrected to include `"daily"` as an accepted
+  `heatmap_granularity` value with inline usage guidance, consistent with
+  the other three granularity options.
 - Contributor ranking now correctly handles tied composite scores. Previously,
   contributors with identical composite scores all received the lowest percentile
   in their group, causing equally active contributors in small teams to be
   assigned the Private designation regardless of their output. Rank computation
   now uses `bisect.bisect_left`, which applies lower-bound percentile semantics
   and is O(log n) per lookup rather than O(n).
+- `assign_tier` unreachable fallback removed. The function previously contained
+  a final return of the undocumented designation "Recruit" that could never be
+  reached. An `AssertionError` is now raised in its place to make any future
+  `_TIER_BOUNDARIES` misconfiguration immediately visible.
 - Daily heatmap chart generation unified through the `_build_heatmap_chart`
   dispatch function. The embedded daily spec and the client-side toggle path
   previously used different `window_end` anchors when `--until` extended beyond
   the latest commit date, producing silently divergent charts. Both paths now
   use `analysis_until` as the anchor.
-- `assign_tier` unreachable fallback removed. The function previously contained
-  a final return of the undocumented designation "Recruit" that could never be
-  reached. An `AssertionError` is now raised in its place to make any future
-  `_TIER_BOUNDARIES` misconfiguration immediately visible.
 - Exception handling in `Renderer.__init__` narrowed from bare `Exception` to
   `TemplateNotFound`, `TemplatesNotFound`, and `OSError`. Unexpected exceptions
   now propagate without being wrapped, preserving diagnostic information at the
@@ -68,9 +67,9 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 - `HeatmapGranularity` type alias consolidated to `reveille.domain.models`,
   eliminating a triplicate definition across `config.py`, `renderer.py`, and
   the TOML validation block. Both layers now import the canonical definition
-  from the domain; the validation tuple is derived via `get_args` so it
-  stays in sync automatically. The error message for invalid TOML values now
-  lists accepted options derived from the type.
+  from the domain; the validation tuple is derived via `get_args` so it stays
+  in sync automatically. The error message for invalid TOML values now lists
+  accepted options derived from the type.
 - `RankingWeights` sum validation tolerance relaxed from `1e-9` to `1e-6`.
   The previous threshold was unnecessarily strict for user-supplied decimal
   weights, where IEEE 754 rounding could plausibly produce deviations

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Reveille is designed for developers, engineering managers, and technical leads w
 
 **What it produces:**
 
-- Contribution heatmaps showing commit activity by day and hour
-- Commit frequency histograms and rolling activity timelines
+- Contribution heatmaps showing commit activity across four granularity levels: per calendar day, per calendar week, per calendar month, and per calendar year — switchable in the rendered report without regeneration
+- Commit frequency timelines and rolling activity charts
 - Per-contributor breakdowns covering commits, lines added and removed, and active day counts
 - A structured ranking table assigning each contributor a tier designation based on weighted activity metrics
-- Repository health indicators including bus factor, activity recency, and consistency scores
+- Repository health indicators including bus factor, longest inactive streak, and consistency scores
 
 **Design constraints that are non-negotiable:**
 
@@ -80,6 +80,14 @@ reveille generate
 
 Reveille reads the local Git history and writes a report to the current directory. The output file is named `reveille-report.html` by default. Open it in any browser.
 
+**Scaffold a configuration file before your first run:**
+
+```bash
+reveille init
+```
+
+This writes an annotated `reveille.toml` to the current directory with every available configuration key present and commented out. Edit only the keys you need, then pass the file with `--config` on subsequent invocations.
+
 **Generate a report for a specific date range:**
 
 ```bash
@@ -117,7 +125,17 @@ Generates the HTML performance report for the target repository.
 | `--min-commits` | | `INT` | `1` | Exclude contributors with fewer than this many commits in the analysis window. |
 | `--title` | | `TEXT` | Repository name | Override the report title displayed in the HTML output. |
 | `--no-ranking` | | Flag | Off | Omit the contributor ranking table from the output. |
+| `--heatmap-granularity` | | `TEXT` | `monthly` | Default heatmap view on open. Accepted values: `daily`, `weekly`, `monthly`, `yearly`. All four views are available via toggle buttons in the rendered report regardless of this setting. |
 | `--config` | `-c` | `PATH` | None | Path to a TOML configuration file. CLI flags take precedence over config file values. |
+
+### `reveille init`
+
+Scaffolds a fully annotated `reveille.toml` configuration file in the current directory. Every available key is present, commented out, and documented inline. Run this once before your first `reveille generate` invocation to produce a starting point you can edit rather than constructing the file from scratch.
+
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--output` | `-o` | `PATH` | `./reveille.toml` | Destination path for the generated configuration file. |
+| `--force` | | Flag | Off | Overwrite an existing file at the target path without prompting. |
 
 ### `reveille version`
 
@@ -139,15 +157,15 @@ The generated HTML file is structured as a formal report with the following sect
 
 **Repository Summary** — Name, remote URL if present, default branch, total commits in the analysis window, unique contributors, date range, and report generation timestamp.
 
-**Activity Heatmap** — A calendar-style matrix showing commit frequency by day across the analysis window. Modelled on GitHub's contribution graph but scoped to the repository and time range specified.
+**Activity Heatmap** — A calendar-style matrix showing commit frequency across the analysis window. Four granularity views are available via toggle buttons in the rendered report: `daily` shows one cell per calendar day in a GitHub-style grid capped at a rolling 365-day window; `weekly` and `monthly` aggregate by day-of-week across each week or month; `yearly` aggregates by month across each calendar year. The `--heatmap-granularity` flag controls which view is active on first open.
 
-**Commit Timeline** — A rolling line chart showing commit volume per week over the analysis window. Highlights periods of high and low activity.
+**Commit Timeline** — A rolling area chart showing commit volume per calendar week over the analysis window. Highlights periods of high and low activity.
 
 **Contributor Summary Table** — A ranked table listing each contributor with their commit count, lines added, lines removed, net line delta, active days, most recent commit date, and assigned tier designation.
 
-**Per-Contributor Activity Charts** — Commit frequency histograms for each contributor showing their distribution of activity across the analysis window.
+**Contribution Breakdown Charts** — Horizontal bar charts of commits and lines changed per contributor, and two donut charts showing each contributor's proportional share of total commits and total lines changed.
 
-**Repository Health Indicators** — Bus factor estimate (minimum number of contributors accounting for 50% of commits), longest inactive streak, activity recency score, and contributor retention across the window.
+**Repository Health Indicators** — Bus factor estimate (minimum number of contributors accounting for 50% of commits) and longest inactive streak within the analysis window.
 
 All charts are rendered with Plotly and are fully interactive — hover states, zoom, pan, and legend toggling are available without any external dependencies.
 
@@ -184,9 +202,7 @@ Tier boundaries and weights are documented defaults and are fully reproducible f
 
 ## Configuration
 
-Reveille accepts a TOML configuration file for parameters that are cumbersome to pass on the command line on every invocation.
-
-Create a file named `reveille.toml` at the repository root or pass the path explicitly with `--config`.
+Reveille accepts a TOML configuration file for parameters that are cumbersome to pass on the command line on every invocation. Run `reveille init` to generate an annotated starting point, or create `reveille.toml` manually at the repository root and pass its path with `--config`.
 
 ```toml
 [report]
@@ -195,6 +211,8 @@ output = "./reports/q4-2024.html"
 branch = "main"
 since = "2024-10-01"
 until = "2024-12-31"
+# Accepted values: "daily", "weekly", "monthly", "yearly"
+heatmap_granularity = "monthly"
 
 [filters]
 min_commits = 2

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,6 +11,7 @@ the [README](../README.md).
 
 - [How Reveille Works](#how-reveille-works)
 - [CLI Flags in Depth](#cli-flags-in-depth)
+- [The reveille init Command](#the-reveille-init-command)
 - [TOML Configuration Reference](#toml-configuration-reference)
 - [Understanding the Report](#understanding-the-report)
 - [The Ranking Algorithm](#the-ranking-algorithm)
@@ -154,13 +155,20 @@ reveille generate --no-ranking
 
 ### `--heatmap-granularity`
 
-Controls the time resolution of the commit activity heatmap. Three
-values are accepted.
+Controls the time resolution of the commit activity heatmap and sets the
+default view when the report is first opened. Four values are accepted.
 
-`weekly` produces one column per calendar week with rows for each day
-of the week. This is the most granular view and is best suited to
-repositories with fewer than six months of history in the analysis
-window. At longer ranges, the chart becomes too wide to read comfortably.
+`daily` produces a GitHub-style grid with one cell per calendar day. Rows
+represent days of the week and columns represent calendar weeks. The view
+is capped at a rolling 365-day window ending at the analysis window's end
+date, preventing excessive chart width for repositories with multi-year
+histories. This view is best for active repositories where per-day
+granularity is meaningful.
+
+`weekly` produces one column per calendar week with rows for each day of
+the week. This is the most granular aggregated view and is best suited to
+repositories with fewer than six months of history in the analysis window.
+At longer ranges, the chart becomes too wide to read comfortably.
 
 `monthly` is the default. It produces one column per calendar month with
 rows for each day of the week. Each cell contains the total commit count
@@ -169,12 +177,17 @@ balances detail and readability for most repository histories.
 
 `yearly` produces one column per calendar year with rows for each month.
 This view is appropriate for repositories with more than three years of
-history, where weekly or monthly resolution would produce an
-unreadably wide chart.
+history, where weekly or monthly resolution would produce an unreadably
+wide chart.
 
 ```bash
-reveille generate --heatmap-granularity weekly
+reveille generate --heatmap-granularity daily
 ```
+
+The generated HTML report embeds all four granularity specifications and
+provides toggle buttons to switch between them without regenerating the
+file. The `--heatmap-granularity` flag controls only which view is active
+on first open.
 
 ### `--config` / `-c`
 
@@ -188,12 +201,53 @@ reveille generate --config ./reveille.toml
 
 ---
 
+## The `reveille init` Command
+
+`reveille init` scaffolds a fully annotated `reveille.toml` configuration
+file in the current directory. Every available configuration key is
+present, commented out, and accompanied by an inline description of its
+purpose and accepted values. Run it once at the root of a repository
+before your first `reveille generate` invocation to produce a starting
+point you can edit rather than constructing the file from scratch.
+
+```bash
+reveille init
+```
+
+The generated file is identical in structure to the [TOML Configuration Reference](#toml-configuration-reference)
+below. All keys are commented out by default, so the file has no effect
+until you uncomment and edit the keys you need. CLI flags always take
+precedence over values in the file, so you can override any setting on a
+per-invocation basis without modifying it.
+
+### `--output` / `-o`
+
+Writes the configuration file to the specified path rather than
+`reveille.toml` in the current directory. The parent directory must
+exist.
+
+```bash
+reveille init --output /path/to/project/reveille.toml
+```
+
+### `--force`
+
+Overwrites an existing configuration file at the target path without
+prompting. Without this flag, `reveille init` exits with an error if the
+file already exists, to prevent accidental data loss.
+
+```bash
+reveille init --force
+```
+
+---
+
 ## TOML Configuration Reference
 
 A TOML configuration file is useful when you run Reveille regularly
 against the same repository with the same parameters. Place it at the
 repository root as `reveille.toml` or pass its path explicitly with
-`--config`.
+`--config`. Use `reveille init` to generate an annotated starting point.
 
 The file is divided into three sections. All sections and all keys are
 optional.
@@ -216,7 +270,9 @@ since = "2024-10-01"
 until = "2024-12-31"
 
 # Heatmap resolution. Equivalent to --heatmap-granularity.
-# Accepted values: "weekly", "monthly", "yearly"
+# Accepted values: "daily", "weekly", "monthly", "yearly"
+# Controls the default view on open; all four are accessible via toggle
+# buttons in the rendered report without regenerating the file.
 heatmap_granularity = "monthly"
 
 
@@ -263,12 +319,22 @@ recorded.
 ### Activity Heatmap
 
 The heatmap visualises when commits occurred across the analysis window.
-Darker cells indicate higher commit volumes. Rows represent days of the
-week in the weekly and monthly views, or months of the year in the yearly
-view. Empty cells — rendered as transparent — indicate periods of no
-activity. Persistent gaps may indicate holidays, sprints with no
-deliverables, or periods of reduced team capacity. The granularity of
-this chart is controlled by `--heatmap-granularity`.
+Darker cells indicate higher commit volumes. Empty cells — rendered as
+transparent — indicate periods of no activity. Persistent gaps may
+indicate holidays, sprints with no deliverables, or periods of reduced
+team capacity.
+
+Four granularity views are available and can be switched using the toggle
+buttons above the chart without regenerating the report. The `daily` view
+shows one cell per calendar day in a GitHub-style grid capped at a rolling
+365-day window; rows are days of the week and columns are calendar weeks.
+The `weekly` and `monthly` views aggregate commit counts by weekday within
+each week or month respectively, with rows for days of the week and columns
+for the time period. The `yearly` view aggregates by month, with rows for
+each month of the year and columns for each calendar year; it is best
+suited to repositories with more than three years of history. The
+`--heatmap-granularity` flag controls which view is active when the file
+is first opened.
 
 ### Weekly Commit Timeline
 
@@ -378,6 +444,20 @@ Commander designation by definition, as their percentile is 100.0.
 ---
 
 ## Practical Patterns
+
+### Scaffolding a Configuration File
+
+Before committing to a set of parameters for a regularly-run report,
+generate an annotated configuration file and edit only the keys you need.
+
+```bash
+reveille init
+```
+
+This writes `reveille.toml` to the current directory with every available
+key present and commented out. Uncomment and set the keys relevant to
+your repository, then run `reveille generate --config reveille.toml` on
+subsequent invocations.
 
 ### Filtering Bot Authors
 


### PR DESCRIPTION
Prepares documentation for the v0.2.0 release. Three commits covering
the CHANGELOG, User Guide, and README in sequence.

## Changes

### CHANGELOG

The `[Unreleased]` entries were reordered to match the actual PR merge
sequence. The previous ordering listed the heatmap features before
`reveille init`, which shipped first in PR #21. All `### Added` and
`### Fixed` entries now follow PR chronological order.

### User Guide

Four updates to `docs/USER_GUIDE.md`:

The `--heatmap-granularity` section now documents `daily` as a fourth
accepted value, including its rolling 365-day window behaviour and the
use cases it suits. A note is added clarifying that all four views are
always accessible via toggle buttons in the rendered report regardless
of the flag value — the flag controls only the default view on open.

A new top-level section, `The reveille init Command`, is added between
CLI Flags in Depth and the TOML Configuration Reference. It covers what
the command does, when to use it, and both of its flags (`--output` and
`--force`) with usage examples.

The TOML Configuration Reference is updated to include `"daily"` in the
accepted values comment for `heatmap_granularity`, and references
`reveille init` as the recommended way to generate a starting point.

The Activity Heatmap subsection under Understanding the Report is
rewritten to describe all four granularity views and explain the
toggle behaviour.

A new Practical Pattern, `Scaffolding a Configuration File`, is added
as the first entry in that section to surface `reveille init` at the
point where users are thinking about repeatable invocations.

### README

Five updates to `README.md`:

The Overview's "What it produces" list is corrected — the previous
description of heatmaps as showing activity "by day and hour" was
inaccurate. It now accurately describes the four granularity levels
and the client-side toggle.

The Quickstart section adds an optional `reveille init` step before
the first `reveille generate` invocation, with a brief explanation of
what the scaffolded file provides.

The `reveille generate` CLI Reference table gains the missing
`--heatmap-granularity` row, which was absent from the original README
despite the flag being present since v0.1.0.

A `reveille init` command section is added to the CLI Reference with
its own flag table covering `--output` and `--force`.

The Configuration section's TOML example is updated to include
`"daily"` in the `heatmap_granularity` accepted values comment, and
the introductory paragraph references `reveille init` as the
recommended way to generate a starting point.