### PR TITLE
chore(tooling): remove black; ruff format is the sole formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,21 +25,13 @@ repos:
 
   # ------------------------------------------------------------------
   # Ruff — linting and import sorting
-  # Runs before black so that any auto-fixes are subsequently formatted.
   # ------------------------------------------------------------------
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.7
     hooks:
       - id: ruff-check
         args: [--fix]
-
-  # ------------------------------------------------------------------
-  # Black — code formatting
-  # ------------------------------------------------------------------
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
+      - id: ruff-format
 
   # ------------------------------------------------------------------
   # Mypy — static type checking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to Reveille are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
+---
+
 ## [Unreleased]
 
+### Changed
+
+- Black removed as a development dependency. `ruff format` is now the
+  sole formatter. `ruff format` has been Black-compatible since Ruff v0.2.0;
+  running both was redundant. The `ruff-format` pre-commit hook replaces
+  the `psf/black` hook at the same `ruff-pre-commit` revision.
+
+---
 
 ## [0.2.0] — 2026-05-06
 
@@ -78,6 +88,7 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   weights, where IEEE 754 rounding could plausibly produce deviations
   approaching `1e-9` despite representing an exact decimal sum of `1.0`.
 
+---
 
 ## [0.1.1] — 2026-04-30
 
@@ -88,6 +99,7 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 - Makefile recipe indentation corrected from spaces to tabs, resolving
   `missing separator` errors on strict Make implementations (PR #16).
 
+---
 
 ## [0.1.0] — 2026-04-30
 
@@ -155,6 +167,7 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   `"category"` and `tickangle` to `-45`, eliminating timestamp-format
   tick labels produced by Plotly's implicit date coercion.
 
+---
 
 [Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.2.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,56 +12,6 @@ files = [
 ]
 
 [[package]]
-name = "black"
-version = "25.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.10"
-files = [
-    {file = "black-25.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f85ba1ad15d446756b4ab5f3044731bf68b777f8f9ac9cdabd2425b97cd9c4e8"},
-    {file = "black-25.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:546eecfe9a3a6b46f9d69d8a642585a6eaf348bcbbc4d87a19635570e02d9f4a"},
-    {file = "black-25.12.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17dcc893da8d73d8f74a596f64b7c98ef5239c2cd2b053c0f25912c4494bf9ea"},
-    {file = "black-25.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:09524b0e6af8ba7a3ffabdfc7a9922fb9adef60fed008c7cd2fc01f3048e6e6f"},
-    {file = "black-25.12.0-cp310-cp310-win_arm64.whl", hash = "sha256:b162653ed89eb942758efeb29d5e333ca5bb90e5130216f8369857db5955a7da"},
-    {file = "black-25.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0cfa263e85caea2cff57d8f917f9f51adae8e20b610e2b23de35b5b11ce691a"},
-    {file = "black-25.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a2f578ae20c19c50a382286ba78bfbeafdf788579b053d8e4980afb079ab9be"},
-    {file = "black-25.12.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e1b65634b0e471d07ff86ec338819e2ef860689859ef4501ab7ac290431f9b"},
-    {file = "black-25.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a3fa71e3b8dd9f7c6ac4d818345237dfb4175ed3bf37cd5a581dbc4c034f1ec5"},
-    {file = "black-25.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:51e267458f7e650afed8445dc7edb3187143003d52a1b710c7321aef22aa9655"},
-    {file = "black-25.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:31f96b7c98c1ddaeb07dc0f56c652e25bdedaac76d5b68a059d998b57c55594a"},
-    {file = "black-25.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:05dd459a19e218078a1f98178c13f861fe6a9a5f88fc969ca4d9b49eb1809783"},
-    {file = "black-25.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1f68c5eff61f226934be6b5b80296cf6939e5d2f0c2f7d543ea08b204bfaf59"},
-    {file = "black-25.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:274f940c147ddab4442d316b27f9e332ca586d39c85ecf59ebdea82cc9ee8892"},
-    {file = "black-25.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:169506ba91ef21e2e0591563deda7f00030cb466e747c4b09cb0a9dae5db2f43"},
-    {file = "black-25.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a05ddeb656534c3e27a05a29196c962877c83fa5503db89e68857d1161ad08a5"},
-    {file = "black-25.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9ec77439ef3e34896995503865a85732c94396edcc739f302c5673a2315e1e7f"},
-    {file = "black-25.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e509c858adf63aa61d908061b52e580c40eae0dfa72415fa47ac01b12e29baf"},
-    {file = "black-25.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:252678f07f5bac4ff0d0e9b261fbb029fa530cfa206d0a636a34ab445ef8ca9d"},
-    {file = "black-25.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bc5b1c09fe3c931ddd20ee548511c64ebf964ada7e6f0763d443947fd1c603ce"},
-    {file = "black-25.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a0953b134f9335c2434864a643c842c44fba562155c738a2a37a4d61f00cad5"},
-    {file = "black-25.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2355bbb6c3b76062870942d8cc450d4f8ac71f9c93c40122762c8784df49543f"},
-    {file = "black-25.12.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9678bd991cc793e81d19aeeae57966ee02909877cb65838ccffef24c3ebac08f"},
-    {file = "black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83"},
-    {file = "black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b"},
-    {file = "black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828"},
-    {file = "black-25.12.0.tar.gz", hash = "sha256:8d3dd9cea14bff7ddc0eb243c811cdb1a011ebb4800a5f0335a01a68654796a7"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-pytokens = ">=0.3.0"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cfgv"
 version = "3.5.0"
 description = "Validate configuration and produce human readable error messages."
@@ -1045,60 +995,6 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
-name = "pytokens"
-version = "0.4.1"
-description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5"},
-    {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe"},
-    {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c"},
-    {file = "pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7"},
-    {file = "pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2"},
-    {file = "pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440"},
-    {file = "pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc"},
-    {file = "pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d"},
-    {file = "pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16"},
-    {file = "pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6"},
-    {file = "pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083"},
-    {file = "pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1"},
-    {file = "pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1"},
-    {file = "pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9"},
-    {file = "pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68"},
-    {file = "pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b"},
-    {file = "pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f"},
-    {file = "pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1"},
-    {file = "pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4"},
-    {file = "pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78"},
-    {file = "pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321"},
-    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa"},
-    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d"},
-    {file = "pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324"},
-    {file = "pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9"},
-    {file = "pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb"},
-    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3"},
-    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975"},
-    {file = "pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a"},
-    {file = "pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918"},
-    {file = "pytokens-0.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:da5baeaf7116dced9c6bb76dc31ba04a2dc3695f3d9f74741d7910122b456edc"},
-    {file = "pytokens-0.4.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:11edda0942da80ff58c4408407616a310adecae1ddd22eef8c692fe266fa5009"},
-    {file = "pytokens-0.4.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1"},
-    {file = "pytokens-0.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dcafc12c30dbaf1e2af0490978352e0c4041a7cde31f4f81435c2a5e8b9cabb6"},
-    {file = "pytokens-0.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:42f144f3aafa5d92bad964d471a581651e28b24434d184871bd02e3a0d956037"},
-    {file = "pytokens-0.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:34bcc734bd2f2d5fe3b34e7b3c0116bfb2397f2d9666139988e7a3eb5f7400e3"},
-    {file = "pytokens-0.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:941d4343bf27b605e9213b26bfa1c4bf197c9c599a9627eb7305b0defcfe40c1"},
-    {file = "pytokens-0.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ad72b851e781478366288743198101e5eb34a414f1d5627cdd585ca3b25f1db"},
-    {file = "pytokens-0.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:682fa37ff4d8e95f7df6fe6fe6a431e8ed8e788023c6bcc0f0880a12eab80ad1"},
-    {file = "pytokens-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:30f51edd9bb7f85c748979384165601d028b84f7bd13fe14d3e065304093916a"},
-    {file = "pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de"},
-    {file = "pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a"},
-]
-
-[package.extras]
-dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "twine", "wheel"]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -1338,4 +1234,4 @@ python-discovery = ">=1.2.2"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "860f5ab2100760c705e208077e218d9af1a2d5bf8aa530df68fd429b9ace7629"
+content-hash = "21f6e289a1deadd74aa50e9b421904c171c42c898259c915f40d072282c12d4a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ types-python-dateutil = "^2.9.0"
 
 # Linting & Formatting
 ruff = "^0.4.0"
-black = "^25.1.0"
 
 # Pre-commit Hooks
 pre-commit = "^3.6.0"

--- a/src/reveille/adapters/git_reader.py
+++ b/src/reveille/adapters/git_reader.py
@@ -120,10 +120,7 @@ class GitReader:
             author_name: str = raw.author.name or ""
             author_email: str = raw.author.email or ""
 
-            if (
-                author_name.lower() in exclude_set
-                or author_email.lower() in exclude_set
-            ):
+            if author_name.lower() in exclude_set or author_email.lower() in exclude_set:
                 continue
 
             stats = raw.stats.total

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -149,9 +149,7 @@ class Renderer:
         try:
             resolved.write_text(html, encoding="utf-8")
         except OSError as exc:
-            raise OutputPathError(
-                f"Failed to write report to '{resolved}': {exc}"
-            ) from exc
+            raise OutputPathError(f"Failed to write report to '{resolved}': {exc}") from exc
 
         return resolved
 
@@ -209,12 +207,8 @@ class Renderer:
             "heatmap_weekly": _build_heatmap_chart(data.commits, "weekly"),
             "heatmap_monthly": _build_heatmap_chart(data.commits, "monthly"),
             "heatmap_yearly": _build_heatmap_chart(data.commits, "yearly"),
-            "contributor_commits": _build_contributor_commits_chart(
-                data.ranked_contributors
-            ),
-            "contributor_lines": _build_contributor_lines_chart(
-                data.ranked_contributors
-            ),
+            "contributor_commits": _build_contributor_commits_chart(data.ranked_contributors),
+            "contributor_lines": _build_contributor_lines_chart(data.ranked_contributors),
             "pie_commits": _build_commit_share_pie(data.ranked_contributors),
             "pie_lines": _build_lines_share_pie(data.ranked_contributors),
         }
@@ -299,9 +293,7 @@ def _build_heatmap_chart(
         return "null"
     if granularity == "daily":
         effective_end = (
-            window_end
-            if window_end is not None
-            else max(c.timestamp.date() for c in commits)
+            window_end if window_end is not None else max(c.timestamp.date() for c in commits)
         )
         return _build_heatmap_daily(commits, effective_end)
     if granularity == "weekly":
@@ -339,8 +331,7 @@ def _build_heatmap_weekly(commits: list[Commit]) -> str:
     num_weeks = max(week_indices) + 1
     z = [[cell.get((w, day), 0) for w in range(num_weeks)] for day in range(7)]
     week_labels = [
-        (base_week + datetime.timedelta(weeks=w)).strftime("%b %d")
-        for w in range(num_weeks)
+        (base_week + datetime.timedelta(weeks=w)).strftime("%b %d") for w in range(num_weeks)
     ]
     day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
@@ -461,9 +452,7 @@ def _build_heatmap_yearly(commits: list[Commit]) -> str:
         "Nov",
         "Dec",
     ]
-    z = [
-        [cell.get((year, month + 1), 0) for year in sorted_years] for month in range(12)
-    ]
+    z = [[cell.get((year, month + 1), 0) for year in sorted_years] for month in range(12)]
 
     fig = go.Figure(
         go.Heatmap(
@@ -551,8 +540,7 @@ def _build_heatmap_daily(
         customdata.append(row_dates)
 
     week_labels = [
-        (base_monday + datetime.timedelta(weeks=w)).strftime("%b %d")
-        for w in range(num_weeks)
+        (base_monday + datetime.timedelta(weeks=w)).strftime("%b %d") for w in range(num_weeks)
     ]
     day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
@@ -687,9 +675,7 @@ def _build_commit_share_pie(ranked: list[RankedContributor]) -> str:
         return "null"
 
     sorted_r = sorted(ranked, key=lambda r: r.stats.commit_count, reverse=True)
-    labels, values = _aggregate_pie_data(
-        [(r.stats.name, r.stats.commit_count) for r in sorted_r]
-    )
+    labels, values = _aggregate_pie_data([(r.stats.name, r.stats.commit_count) for r in sorted_r])
 
     fig = go.Figure(
         go.Pie(
@@ -728,9 +714,7 @@ def _build_lines_share_pie(ranked: list[RankedContributor]) -> str:
         return "null"
 
     sorted_r = sorted(ranked, key=lambda r: r.stats.lines_changed, reverse=True)
-    labels, values = _aggregate_pie_data(
-        [(r.stats.name, r.stats.lines_changed) for r in sorted_r]
-    )
+    labels, values = _aggregate_pie_data([(r.stats.name, r.stats.lines_changed) for r in sorted_r])
 
     fig = go.Figure(
         go.Pie(

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -111,7 +111,8 @@ def _merge_cli_flags(
 
     if output != Path("reveille-report.html") or "output_path" not in merged:
         merged["output_path"] = _resolve_output_path(
-            output, merged["repo_path"]  # type: ignore[arg-type]
+            output,
+            merged["repo_path"],  # type: ignore[arg-type]
         )
     if since is not None:
         merged["since"] = _parse_date(since, "--since")
@@ -145,21 +146,15 @@ def generate(
     ] = Path("reveille-report.html"),
     since: Annotated[
         str | None,
-        typer.Option(
-            "--since", help="Include commits on or after this date (YYYY-MM-DD)."
-        ),
+        typer.Option("--since", help="Include commits on or after this date (YYYY-MM-DD)."),
     ] = None,
     until: Annotated[
         str | None,
-        typer.Option(
-            "--until", help="Include commits on or before this date (YYYY-MM-DD)."
-        ),
+        typer.Option("--until", help="Include commits on or before this date (YYYY-MM-DD)."),
     ] = None,
     branch: Annotated[
         str | None,
-        typer.Option(
-            "--branch", "-b", help="Analyse commits reachable from this branch only."
-        ),
+        typer.Option("--branch", "-b", help="Analyse commits reachable from this branch only."),
     ] = None,
     exclude_author: Annotated[
         list[str] | None,
@@ -170,9 +165,7 @@ def generate(
     ] = None,
     min_commits: Annotated[
         int | None,
-        typer.Option(
-            "--min-commits", help="Exclude contributors below this commit threshold."
-        ),
+        typer.Option("--min-commits", help="Exclude contributors below this commit threshold."),
     ] = None,
     title: Annotated[
         str | None,
@@ -180,9 +173,7 @@ def generate(
     ] = None,
     no_ranking: Annotated[
         bool,
-        typer.Option(
-            "--no-ranking", help="Omit the contributor ranking table from the output."
-        ),
+        typer.Option("--no-ranking", help="Omit the contributor ranking table from the output."),
     ] = False,
     heatmap_granularity: Annotated[
         str | None,

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -91,14 +91,8 @@ class ReportConfig(BaseModel):
         Raises:
             ValueError: If since is later than until.
         """
-        if (
-            self.since is not None
-            and self.until is not None
-            and self.since > self.until
-        ):
-            raise ValueError(
-                f"since ({self.since}) must be earlier than until ({self.until})."
-            )
+        if self.since is not None and self.until is not None and self.since > self.until:
+            raise ValueError(f"since ({self.since}) must be earlier than until ({self.until}).")
         return self
 
 
@@ -126,9 +120,7 @@ def load_config_from_toml(path: Path) -> dict[str, Any]:
     except FileNotFoundError as exc:
         raise ConfigurationError(f"Configuration file not found: '{path}'.") from exc
     except tomllib.TOMLDecodeError as exc:
-        raise ConfigurationError(
-            f"Configuration file is not valid TOML: {exc}"
-        ) from exc
+        raise ConfigurationError(f"Configuration file is not valid TOML: {exc}") from exc
 
     kwargs: dict[str, Any] = {}
     kwargs.update(_parse_report_section(raw.get("report", {})))

--- a/src/reveille/init.py
+++ b/src/reveille/init.py
@@ -145,8 +145,6 @@ def write_init_config(output_path: Path, *, force: bool = False) -> Path:
     try:
         resolved.write_text(_DEFAULT_CONFIG_TEMPLATE, encoding="utf-8")
     except OSError as exc:
-        raise OutputPathError(
-            f"Failed to write configuration file to '{resolved}': {exc}"
-        ) from exc
+        raise OutputPathError(f"Failed to write configuration file to '{resolved}': {exc}") from exc
 
     return resolved

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -52,9 +52,7 @@ def generate_report(config: ReportConfig) -> Path:
     )
 
     window_start = (
-        config.since
-        if config.since is not None
-        else min(c.timestamp.date() for c in commits)
+        config.since if config.since is not None else min(c.timestamp.date() for c in commits)
     )
     window_end = config.until or datetime.date.today()
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -188,9 +188,7 @@ class TestGenerateCommand:
 
     # -- Default output structure (shared fixture, no redundant rendering) --
 
-    def test_generates_html_file_at_default_path(
-        self, default_report_content: str
-    ) -> None:
+    def test_generates_html_file_at_default_path(self, default_report_content: str) -> None:
         assert len(default_report_content) > 0
 
     def test_output_is_valid_html(self, default_report_content: str) -> None:
@@ -200,15 +198,11 @@ class TestGenerateCommand:
     def test_output_contains_plotly_bundle(self, default_report_content: str) -> None:
         assert "plotly" in default_report_content.lower()
 
-    def test_output_contains_contributor_names(
-        self, default_report_content: str
-    ) -> None:
+    def test_output_contains_contributor_names(self, default_report_content: str) -> None:
         assert "Alice" in default_report_content
         assert "Bob" in default_report_content
 
-    def test_output_file_has_no_external_script_tags(
-        self, default_report_content: str
-    ) -> None:
+    def test_output_file_has_no_external_script_tags(self, default_report_content: str) -> None:
         import re
 
         external_tags = re.findall(
@@ -216,8 +210,7 @@ class TestGenerateCommand:
             default_report_content,
         )
         assert external_tags == [], (
-            f"Report contains {len(external_tags)} external script reference(s): "
-            f"{external_tags}"
+            f"Report contains {len(external_tags)} external script reference(s): {external_tags}"
         )
 
     # -- Distinct invocations (different flags, cannot share) --
@@ -473,9 +466,7 @@ class TestGenerateCommand:
         )
         assert result.exit_code == 1
 
-    def test_output_embeds_all_four_heatmap_specs(
-        self, default_report_content: str
-    ) -> None:
+    def test_output_embeds_all_four_heatmap_specs(self, default_report_content: str) -> None:
         """All three heatmap granularity specs are present in the output."""
         assert 'id="spec-heatmap-weekly"' in default_report_content
         assert 'id="spec-heatmap-monthly"' in default_report_content
@@ -501,9 +492,7 @@ class TestInitCommand:
         assert result.exit_code == 0
         assert dest.exists()
 
-    def test_output_confirms_written_path(
-        self, tmp_path_factory: pytest.TempPathFactory
-    ) -> None:
+    def test_output_confirms_written_path(self, tmp_path_factory: pytest.TempPathFactory) -> None:
         """The success message includes the written path."""
         dest = tmp_path_factory.mktemp("init_confirm") / "reveille.toml"
         result = runner.invoke(app, ["init", "--output", str(dest)])

--- a/tests/integration/test_git_reader.py
+++ b/tests/integration/test_git_reader.py
@@ -142,9 +142,7 @@ def fixture_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
 class TestGitReaderInit:
     """Tests for GitReader initialisation and path validation."""
 
-    def test_valid_repository_initialises_without_error(
-        self, fixture_repo: Path
-    ) -> None:
+    def test_valid_repository_initialises_without_error(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
         assert reader is not None
 
@@ -170,16 +168,12 @@ class TestReadCommits:
 
     def test_returns_all_commits_without_filters(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         assert len(commits) == 5
 
     def test_commits_are_sorted_most_recent_first(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         timestamps = [c.timestamp for c in commits]
         assert timestamps == sorted(timestamps, reverse=True)
 
@@ -236,9 +230,7 @@ class TestReadCommits:
         )
         assert len(commits) == 3
 
-    def test_empty_window_raises_empty_repository_error(
-        self, fixture_repo: Path
-    ) -> None:
+    def test_empty_window_raises_empty_repository_error(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
         with pytest.raises(EmptyRepositoryError):
             reader.read_commits(
@@ -270,9 +262,7 @@ class TestAggregateContributorStats:
 
     def test_returns_one_entry_per_unique_contributor(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
@@ -281,9 +271,7 @@ class TestAggregateContributorStats:
 
     def test_alice_has_three_commits(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
@@ -293,9 +281,7 @@ class TestAggregateContributorStats:
 
     def test_sorted_by_commit_count_descending(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,
@@ -303,13 +289,9 @@ class TestAggregateContributorStats:
         counts = [s.commit_count for s in stats]
         assert counts == sorted(counts, reverse=True)
 
-    def test_min_commits_filters_low_activity_contributors(
-        self, fixture_repo: Path
-    ) -> None:
+    def test_min_commits_filters_low_activity_contributors(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         # Bob has 2 commits. min_commits=3 should exclude him.
         stats = reader.aggregate_contributor_stats(
             commits=commits,
@@ -318,13 +300,9 @@ class TestAggregateContributorStats:
         assert len(stats) == 1
         assert stats[0].email == "alice@example.com"
 
-    def test_active_days_counts_distinct_calendar_dates(
-        self, fixture_repo: Path
-    ) -> None:
+    def test_active_days_counts_distinct_calendar_dates(self, fixture_repo: Path) -> None:
         reader = GitReader(fixture_repo)
-        commits = reader.read_commits(
-            branch=None, since=None, until=None, exclude_authors=[]
-        )
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
         stats = reader.aggregate_contributor_stats(
             commits=commits,
             min_commits=1,

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -167,9 +167,7 @@ class TestComputeLongestInactiveStreak:
         end = datetime.date(2024, 1, 5)
         commits = [_make_commit(start + datetime.timedelta(days=i)) for i in range(5)]
         assert (
-            _compute_longest_inactive_streak(
-                commits=commits, window_start=start, window_end=end
-            )
+            _compute_longest_inactive_streak(commits=commits, window_start=start, window_end=end)
             == 0
         )
 
@@ -360,9 +358,7 @@ class TestBuildHeatmapDaily:
 
     def test_returns_valid_chart_json(self) -> None:
         commits = [_make_commit(datetime.date(2024, 1, 8))]
-        assert _is_valid_chart_json(
-            _build_heatmap_daily(commits, datetime.date(2024, 1, 31))
-        )
+        assert _is_valid_chart_json(_build_heatmap_daily(commits, datetime.date(2024, 1, 31)))
 
     def test_z_matrix_has_seven_rows(self) -> None:
         """Seven rows correspond to the seven days of the week."""
@@ -382,9 +378,7 @@ class TestBuildHeatmapDaily:
         """A commit within max_days of window_end produces a valid chart."""
         recent = _make_commit(datetime.date(2024, 3, 1))
         window_end = datetime.date(2024, 3, 31)
-        assert _is_valid_chart_json(
-            _build_heatmap_daily([recent], window_end, max_days=90)
-        )
+        assert _is_valid_chart_json(_build_heatmap_daily([recent], window_end, max_days=90))
 
     def test_column_count_matches_weeks_in_rolling_window(self) -> None:
         """Column count equals the number of calendar weeks in the window.
@@ -394,9 +388,7 @@ class TestBuildHeatmapDaily:
         Weeks: Jan 01, Jan 08, Jan 15, Jan 22 -> 4 columns.
         """
         commits = [_make_commit(datetime.date(2024, 1, 15))]
-        parsed = json.loads(
-            _build_heatmap_daily(commits, datetime.date(2024, 1, 28), max_days=28)
-        )
+        parsed = json.loads(_build_heatmap_daily(commits, datetime.date(2024, 1, 28), max_days=28))
         assert len(parsed["data"][0]["x"]) == 4
 
     def test_xaxis_type_is_category(self) -> None:
@@ -415,9 +407,7 @@ class TestBuildHeatmapDaily:
 
     def test_dispatch_daily_via_build_heatmap_chart(self) -> None:
         commits = [_make_commit(datetime.date(2024, 1, 8))]
-        result = _build_heatmap_chart(
-            commits, "daily", window_end=datetime.date(2024, 1, 31)
-        )
+        result = _build_heatmap_chart(commits, "daily", window_end=datetime.date(2024, 1, 31))
         assert _is_valid_chart_json(result)
 
     def test_dispatch_daily_without_window_end_defaults_to_max_commit_date(
@@ -469,9 +459,7 @@ class TestBuildContributorLinesChart:
         assert _build_contributor_lines_chart([]) == "null"
 
     def test_single_contributor_returns_valid_chart_json(self) -> None:
-        ranked = [
-            _make_ranked("Alice", commit_count=10, lines_added=500, lines_deleted=80)
-        ]
+        ranked = [_make_ranked("Alice", commit_count=10, lines_added=500, lines_deleted=80)]
         assert _is_valid_chart_json(_build_contributor_lines_chart(ranked))
 
     def test_multiple_contributors_return_valid_chart_json(self) -> None:

--- a/tests/unit/domain/test_ranking.py
+++ b/tests/unit/domain/test_ranking.py
@@ -295,9 +295,7 @@ class TestComputeRecencyScore:
         anchor = datetime.date(2024, 3, 31)
         recent = [_make_commit("a@x.com", datetime.date(2024, 3, 25))]
         older = [_make_commit("a@x.com", datetime.date(2024, 1, 5))]
-        assert _compute_recency_score(recent, anchor) > _compute_recency_score(
-            older, anchor
-        )
+        assert _compute_recency_score(recent, anchor) > _compute_recency_score(older, anchor)
 
     def test_score_is_non_negative(self) -> None:
         anchor = datetime.date(2024, 3, 31)


### PR DESCRIPTION
ruff format has been Black-compatible since Ruff v0.2.0. Running both formatters on every commit was redundant. Removes black from dev dependencies and replaces the psf/black pre-commit hook with the ruff-format hook from the same ruff-pre-commit repository.