### PR TITLE
feat: progress indicator for reveille generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Progress indicator for `reveille generate`. Stage-level status lines
+  are emitted to stderr as the pipeline advances through reading commit
+  history, aggregating contributor statistics, ranking contributors, and
+  rendering the report. Each stage animates until complete, then resolves
+  to a static completion line. Stderr is used so stdout remains clean for
+  scripting. Implemented via an optional `on_progress` callback on
+  `generate_report`; the service layer remains unaware of the CLI.
+
 ### Changed
 
 - Black removed as a development dependency. `ruff format` is now the

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -12,8 +12,12 @@ Entry point registered in pyproject.toml:
 from __future__ import annotations
 
 import datetime
+import itertools
+import sys
+import threading
+from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, ClassVar
 
 import typer
 
@@ -27,6 +31,78 @@ app = typer.Typer(
     add_completion=False,
     no_args_is_help=True,
 )
+
+
+class _StageSpinner:
+    """Per-stage progress indicator for the generate pipeline.
+
+    Writes animated stage labels to stderr. Each stage begins with
+    begin() and resolves to a static completion line on complete().
+    Writes to stderr so stdout remains clean for scripting.
+
+    complete() is safe to call before begin() has ever been invoked.
+    """
+
+    _FRAMES: ClassVar[list[str]] = [".  ", ".. ", "..."]
+
+    def __init__(self) -> None:
+        self._active: bool = False
+        self._stop_event: threading.Event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._label: str = ""
+
+    def begin(self, label: str) -> None:
+        """Start the animated indicator for a new pipeline stage.
+
+        Args:
+            label: Human-readable stage name written to stderr.
+        """
+        self._label = label
+        self._stop_event.clear()
+        self._active = True
+        self._thread = threading.Thread(target=self._run, args=(label,), daemon=True)
+        self._thread.start()
+
+    def complete(self) -> None:
+        """Stop the current animation and write the completion line.
+
+        No-op if begin() has not been called or if already completed.
+        """
+        if not self._active:
+            return
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+        self._active = False
+
+    def _run(self, label: str) -> None:
+        for frame in itertools.cycle(self._FRAMES):
+            sys.stderr.write(f"\r  {label} {frame}")
+            sys.stderr.flush()
+            if self._stop_event.wait(0.2):
+                break
+        sys.stderr.write(f"\r  {label} ...   done\n")
+        sys.stderr.flush()
+
+
+def _make_progress_callback(spinner: _StageSpinner) -> Callable[[str], None]:
+    """Return a progress callback that drives the given spinner.
+
+    On each invocation, completes the previous stage animation and
+    starts a new one for the incoming label.
+
+    Args:
+        spinner: The _StageSpinner instance to drive.
+
+    Returns:
+        A callable suitable for passing as on_progress to generate_report.
+    """
+
+    def _callback(label: str) -> None:
+        spinner.complete()
+        spinner.begin(label)
+
+    return _callback
 
 
 def _version_callback(value: bool) -> None:
@@ -222,12 +298,19 @@ def generate(
         typer.echo(f"Configuration error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
+    spinner = _StageSpinner()
     try:
-        written_path = generate_report(report_config)
-        typer.echo(f"Report written to: {written_path}")
+        written_path = generate_report(
+            report_config,
+            on_progress=_make_progress_callback(spinner),
+        )
     except RevelleError as exc:
+        spinner.complete()
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
+    else:
+        spinner.complete()
+        typer.echo(f"Report written to: {written_path}")
 
 
 @app.command()

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -17,6 +17,7 @@ or Typer. All external concerns are delegated to adapters.
 from __future__ import annotations
 
 import datetime
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 
@@ -27,11 +28,17 @@ from reveille.domain.models import RankedContributor, ReportData
 from reveille.domain.ranking import rank_contributors
 
 
-def generate_report(config: ReportConfig) -> Path:
+def generate_report(
+    config: ReportConfig,
+    on_progress: Callable[[str], None] | None = None,
+) -> Path:
     """Generate a self-contained HTML performance report.
 
     Args:
         config: Validated report configuration produced by the CLI layer.
+        on_progress: Optional callable invoked with a stage label string
+            at the start of each pipeline stage. Intended for CLI progress
+            display. Has no effect on the output when omitted.
 
     Returns:
         The absolute path of the written HTML file.
@@ -44,6 +51,8 @@ def generate_report(config: ReportConfig) -> Path:
     """
     reader = GitReader(config.repo_path)
 
+    if on_progress is not None:
+        on_progress("Reading commit history")
     commits = reader.read_commits(
         branch=config.branch,
         since=config.since,
@@ -56,6 +65,8 @@ def generate_report(config: ReportConfig) -> Path:
     )
     window_end = config.until or datetime.date.today()
 
+    if on_progress is not None:
+        on_progress("Aggregating contributor statistics")
     contributor_stats = reader.aggregate_contributor_stats(
         commits=commits,
         min_commits=config.min_commits,
@@ -63,6 +74,8 @@ def generate_report(config: ReportConfig) -> Path:
 
     ranked_contributors: list[RankedContributor]
     if config.ranking_enabled and contributor_stats:
+        if on_progress is not None:
+            on_progress("Ranking contributors")
         ranked_contributors = rank_contributors(
             contributors=contributor_stats,
             commits=commits,
@@ -88,7 +101,6 @@ def generate_report(config: ReportConfig) -> Path:
         analysis_since=window_start,
         analysis_until=window_end,
     )
-
     if config.title:
         metadata = replace(metadata, name=config.title)
 
@@ -98,5 +110,7 @@ def generate_report(config: ReportConfig) -> Path:
         commits=commits,
     )
 
+    if on_progress is not None:
+        on_progress("Rendering report")
     renderer = Renderer()
     return renderer.render(report_data, config.output_path, config.heatmap_granularity)

--- a/tests/unit/services/test_report.py
+++ b/tests/unit/services/test_report.py
@@ -287,3 +287,38 @@ class TestGenerateReport:
             generate_report(minimal_config)
 
         assert captured[0].commits == [sample_commit]
+
+    def test_progress_callback_invoked_at_each_stage_in_order(
+        self,
+        minimal_config: ReportConfig,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        """on_progress is called once per pipeline stage in execution order."""
+        calls: list[str] = []
+
+        def capture(label: str) -> None:
+            calls.append(label)
+
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+            mock_renderer.return_value.render.return_value = Path("out.html")
+
+            generate_report(minimal_config, on_progress=capture)
+
+        assert calls == [
+            "Reading commit history",
+            "Aggregating contributor statistics",
+            "Ranking contributors",
+            "Rendering report",
+        ]


### PR DESCRIPTION
## Summary

Adds stage-level progress output to `reveille generate`. On large
repositories the pipeline ran silently for several seconds with no
terminal feedback. This PR resolves that by emitting an animated
status line to stderr at each stage transition.

## Changes

**`src/reveille/services/report.py`**
Added an optional `on_progress: Callable[[str], None] | None` parameter
to `generate_report`. The service calls it with a stage label string at
the start of each pipeline stage: reading commit history, aggregating
contributor statistics, ranking contributors, and rendering the report.
The service layer has no knowledge of the CLI — the callback is an opaque
callable.

**`src/reveille/cli.py`**
Added `_StageSpinner` — a threading-based per-stage indicator that writes
to stderr. Each stage animates until `complete()` is called, then resolves
to a static completion line. Added `_make_progress_callback` which drives
the spinner from the `on_progress` contract. The `generate` command
constructs a spinner, wires the callback, and guarantees `complete()` is
called on both the success and error paths.

**`tests/unit/services/test_report.py`**
One new test: `test_progress_callback_invoked_at_each_stage_in_order`
verifies the callback receives all four stage labels in pipeline execution
order.

**`CHANGELOG.md`**
`[Unreleased]` updated.

## Test results

```
pytest -n auto   →   all tests passing
pre-commit run --all-files   →   all hooks passing
```

## Notes

- stderr is used throughout so stdout remains clean for scripting
- `complete()` is safe to call before `begin()` has been invoked (no-op)
- the spinner thread is daemonised; it cannot block process exit