### PR TITLE
fix: validate git repository root before writing init config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   running both was redundant. The `ruff-format` pre-commit hook replaces
   the `psf/black` hook at the same `ruff-pre-commit` revision.
 
+### Fixed
+
+- `reveille init` now validates that the current working directory is a
+  Git repository root before writing the configuration file. Previously
+  the command wrote the file unconditionally, producing a configuration
+  that referenced a non-repository path and could not be used with
+  `reveille generate`. Running `init` outside a repository root now exits
+  with a non-zero status and a diagnostic message.
+
 ---
 
 ## [0.2.0] — 2026-05-06

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -352,6 +352,15 @@ def init(
     (or the path specified by --output) with all keys present and set to
     their defaults. Uncomment and edit only the keys you want to override.
     """
+    cwd = Path(".").resolve()
+    if not (cwd / ".git").exists():
+        typer.echo(
+            f"Error: '{cwd}' is not a Git repository root. "
+            "Run reveille init from within a repository root.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     from reveille.init import write_init_config
 
     try:

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -525,3 +525,20 @@ class TestInitCommand:
         dest = base / "nonexistent_dir" / "reveille.toml"
         result = runner.invoke(app, ["init", "--output", str(dest)])
         assert result.exit_code != 0
+
+    def test_exits_nonzero_outside_git_repository(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """Non-zero exit and no file written when CWD is not a Git repository."""
+        import os
+
+        non_git = tmp_path_factory.mktemp("non_git_cwd")
+        dest = non_git / "reveille.toml"
+        original = Path(os.getcwd())
+        try:
+            os.chdir(non_git)
+            result = runner.invoke(app, ["init", "--output", str(dest)])
+        finally:
+            os.chdir(original)
+        assert result.exit_code != 0
+        assert not dest.exists()


### PR DESCRIPTION
## Summary

`reveille init` previously wrote a configuration file unconditionally
with no check that the current directory is a Git repository. A
configuration file written outside a repository context is not
actionable — `reveille generate` will fail when it reads the config
and attempts to open a non-repository path.

## Change

**`src/reveille/cli.py`**
Added a `.git` directory check against the resolved current working
directory at the start of the `init` command. If the check fails, the
command exits with a non-zero status and a diagnostic message before
any file I/O occurs. No changes to `write_init_config` — the fix
belongs at the CLI boundary, consistent with how `validate` applies
the same guard.

**`tests/e2e/test_cli.py`**
One new test: `test_exits_nonzero_outside_git_repository`. Changes
CWD to a plain temp directory, invokes `init`, restores CWD in a
`finally` block, and asserts non-zero exit and no file written.

**`CHANGELOG.md`**
`[Unreleased]` updated.

## Test results

```
pytest -n auto   →   all tests passing
pre-commit run --all-files   →   all hooks passing
```