### PR TITLE
feat: auto-discover reveille.toml at current working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   to a static completion line. Stderr is used so stdout remains clean for
   scripting. Implemented via an optional `on_progress` callback on
   `generate_report`; the service layer remains unaware of the CLI.
+- `reveille generate` auto-discovers `reveille.toml` at the current working
+  directory when `--config` is not provided. A fully commented file applies
+  all built-in defaults. A partially configured file applies only the keys
+  present; absent keys fall back to defaults. A malformed file exits with a
+  non-zero status, a parse error detail, and an explicit remediation hint to
+  correct the syntax or regenerate the file with `reveille init --force`.
+  The `--config` flag remains available for non-standard file names and
+  paths.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ pip install reveille
 pipx install reveille
 ```
 
+**Install with Poetry (within a Poetry-managed project):**
+
+```bash
+poetry add reveille
+```
+
+**Install with uv:**
+
+```bash
+uv tool install reveille
+```
+
+**Run without a permanent install (uv):**
+
+```bash
+uvx reveille generate --repo /path/to/repository
+```
+
 **Verify the installation:**
 
 ```bash
@@ -86,7 +104,7 @@ Reveille reads the local Git history and writes a report to the current director
 reveille init
 ```
 
-This writes an annotated `reveille.toml` to the current directory with every available configuration key present and commented out. Edit only the keys you need, then pass the file with `--config` on subsequent invocations.
+This writes an annotated `reveille.toml` to the current directory with every available configuration key present and commented out. Edit only the keys you need. On all subsequent invocations, `reveille generate` will detect and load `reveille.toml` automatically — no `--config` flag required.
 
 **Generate a report for a specific date range:**
 
@@ -126,7 +144,7 @@ Generates the HTML performance report for the target repository.
 | `--title` | | `TEXT` | Repository name | Override the report title displayed in the HTML output. |
 | `--no-ranking` | | Flag | Off | Omit the contributor ranking table from the output. |
 | `--heatmap-granularity` | | `TEXT` | `monthly` | Default heatmap view on open. Accepted values: `daily`, `weekly`, `monthly`, `yearly`. All four views are available via toggle buttons in the rendered report regardless of this setting. |
-| `--config` | `-c` | `PATH` | None | Path to a TOML configuration file. CLI flags take precedence over config file values. |
+| `--config` | `-c` | `PATH` | None | Path to a TOML configuration file. If omitted, `reveille.toml` in the current working directory is loaded automatically when present. Use this flag for non-standard file names or paths outside the repository root. CLI flags always take precedence over configuration file values. |
 
 ### `reveille init`
 
@@ -202,7 +220,13 @@ Tier boundaries and weights are documented defaults and are fully reproducible f
 
 ## Configuration
 
-Reveille accepts a TOML configuration file for parameters that are cumbersome to pass on the command line on every invocation. Run `reveille init` to generate an annotated starting point, or create `reveille.toml` manually at the repository root and pass its path with `--config`.
+Reveille accepts a TOML configuration file for parameters that are cumbersome to pass on the command line on every invocation.
+
+**Canonical workflow.** Run `reveille init` from your repository root to generate an annotated `reveille.toml`. Edit only the keys relevant to your analysis. From that point, `reveille generate` detects and loads `reveille.toml` automatically on every invocation — no flag required.
+
+**Non-standard paths.** If the configuration file is named differently or stored outside the repository root, pass its path explicitly with `--config`. This is also the appropriate path for automation scripts that maintain multiple named configuration files for different analysis windows.
+
+A fully commented `reveille.toml` is equivalent to no configuration file: all built-in defaults apply. A partially configured file applies only the keys present; absent keys fall back to defaults. A malformed file causes `reveille generate` to exit with a non-zero status, a parse error detail, and a remediation hint.
 
 ```toml
 [report]

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -33,6 +33,28 @@ app = typer.Typer(
 )
 
 
+# Conventional configuration file name. Resolved against the current
+# working directory at invocation time. Users are not required to pass
+# --config when this file is present at the repository root.
+_CONVENTIONAL_CONFIG: str = "reveille.toml"
+
+
+def _discover_config() -> Path | None:
+    """Return the path to the conventional configuration file if present.
+
+    Looks for reveille.toml in the current working directory. This
+    implements the convention-over-configuration lookup: users who run
+    reveille generate from their repository root do not need to pass
+    --config explicitly when the canonical file name is used.
+
+    Returns:
+        The Path to reveille.toml if it exists in the current directory,
+        or None if no conventional configuration file is present.
+    """
+    candidate = Path(_CONVENTIONAL_CONFIG)
+    return candidate if candidate.exists() else None
+
+
 class _StageSpinner:
     """Per-stage progress indicator for the generate pipeline.
 
@@ -271,11 +293,22 @@ def generate(
     from reveille.services.report import generate_report
 
     config_kwargs: dict[str, object] = {}
-    if config is not None:
+    _auto_discovered = config is None
+    _config_path = config if config is not None else _discover_config()
+    if _config_path is not None:
         try:
-            config_kwargs = load_config_from_toml(config)
+            config_kwargs = load_config_from_toml(_config_path)
         except ConfigurationError as exc:
-            typer.echo(f"Configuration error: {exc}", err=True)
+            if _auto_discovered:
+                typer.echo(
+                    f"Configuration error: auto-discovered {_CONVENTIONAL_CONFIG} "
+                    f"contains invalid TOML.\nDetail: {exc}\n"
+                    f"Correct the syntax or regenerate the file with: "
+                    f"reveille init --force",
+                    err=True,
+                )
+            else:
+                typer.echo(f"Configuration error: {exc}", err=True)
             raise typer.Exit(code=1) from exc
 
     merged = _merge_cli_flags(

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -473,6 +473,54 @@ class TestGenerateCommand:
         assert 'id="spec-heatmap-yearly"' in default_report_content
         assert 'id="spec-heatmap-daily"' in default_report_content
 
+    def test_auto_discovers_reveille_toml_in_cwd(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """reveille.toml at CWD is loaded without --config when present."""
+        work_dir = tmp_path_factory.mktemp("auto_discover_cwd")
+        output = work_dir / "report.html"
+        (work_dir / "reveille.toml").write_text(
+            '[report]\ntitle = "Auto Discovered Title"\n',
+            encoding="utf-8",
+        )
+        original = Path(os.getcwd())
+        try:
+            os.chdir(work_dir)
+            result = runner.invoke(
+                app,
+                ["generate", "--repo", str(e2e_repo), "--output", str(output)],
+            )
+        finally:
+            os.chdir(original)
+        assert result.exit_code == 0
+        assert "Auto Discovered Title" in output.read_text(encoding="utf-8")
+
+    def test_malformed_auto_discovered_config_exits_with_remediation_hint(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """Malformed auto-discovered reveille.toml exits nonzero with remediation guidance."""
+        work_dir = tmp_path_factory.mktemp("malformed_auto_discover")
+        output = work_dir / "report.html"
+        (work_dir / "reveille.toml").write_text(
+            "[report]\ntitle = missing quotes\n",
+            encoding="utf-8",
+        )
+        original = Path(os.getcwd())
+        try:
+            os.chdir(work_dir)
+            result = runner.invoke(
+                app,
+                ["generate", "--repo", str(e2e_repo), "--output", str(output)],
+            )
+        finally:
+            os.chdir(original)
+        assert result.exit_code == 1
+        assert "reveille init --force" in result.output
+
 
 # ------------------------------------------------------------------
 # Init command


### PR DESCRIPTION
## Summary

`reveille generate` now auto-discovers `reveille.toml` at the current
working directory when `--config` is not provided. Combined with
`reveille init`, this closes the loop on the canonical configuration
workflow: scaffold once, generate without flags on every subsequent run.

## Changes

**`src/reveille/cli.py`**
Added `_CONVENTIONAL_CONFIG` constant and `_discover_config()` helper.
The config loading block in `generate` resolves the effective config
path before loading: explicit `--config` takes priority; if absent,
`_discover_config()` returns `reveille.toml` from CWD when present;
if neither, all built-in defaults apply. The auto-discovered vs
explicitly-passed distinction is preserved so the error message for a
malformed auto-discovered file includes a `reveille init --force`
remediation hint.

**`tests/e2e/test_cli.py`**
Two new tests: `test_auto_discovers_reveille_toml_in_cwd` verifies a
title set in an auto-discovered config appears in the output without
`--config`; `test_malformed_auto_discovered_config_exits_with_remediation_hint`
verifies a parse-invalid file exits nonzero and the output contains
`reveille init --force`.

**`README.md`**
Installation section updated to include `uv tool install`, `uvx`, and
`poetry add`. Quickstart section corrected to remove the now-inaccurate
instruction to pass `--config` after running `reveille init`.
Configuration section restructured to present the canonical workflow
first and the `--config` flag as the override path for non-standard
configurations. `--config` flag description in the CLI Reference table
updated accordingly.

**`CHANGELOG.md`**
`[Unreleased]` updated.

## Test results

```
pytest -n auto   →   all tests passing
pre-commit run --all-files   →   all hooks passing
```