### PR TITLE
chore(release): bump version to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.3.3] — 2026-05-12
+
 ### Added
 
 - `reveille help` command that displays the top-level help text listing all
@@ -221,7 +225,8 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.3.3
 [0.3.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.3.0
 [0.2.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.2.0
 [0.1.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.3.0"
+version = "0.3.3"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Varaprasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "MIT"

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -4,7 +4,7 @@ A CLI tool that generates self-contained HTML performance reports
 from local Git repositories.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.3"
 __author__ = "Varaprasad Chilakanti"
 __email__ = "varaprasadchilakanti@gmail.com"
 __licence__ = "MIT"


### PR DESCRIPTION
### Added

- `reveille help` command that displays the top-level help text listing all
  available commands and global options. Supplements the existing
  `reveille --help` flag with a subcommand form that matches the instinctive
  typing pattern for users familiar with Git-style CLIs.
- `-h` accepted as a short form of `--help` on all commands. `reveille -h`,
  `reveille generate -h`, `reveille init -h`, and `reveille validate -h` all
  display the relevant help text. Implemented via Click's `help_option_names`
  context setting, which propagates the alias to every subcommand without
  per-command wiring.

### Fixed

- Upgraded Typer from `^0.12.0` to `^0.18.0` and removed the `click <8.3.0`
  upper bound. Click 8.3.0 (released September 2025) introduced a breaking
  change to `Parameter.make_metavar()` that caused a `TypeError` whenever
  Reveille attempted to render help output — including on bare `reveille`
  invocations due to `no_args_is_help=True`. Typer 0.18.0 restores full
  Click 8.3.x compatibility.
