### PR TITLE
feat(renderer,template): GitHub-style year-navigable heatmap with per-contributor selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   display the relevant help text. Implemented via Click's `help_option_names`
   context setting, which propagates the alias to every subcommand without
   per-command wiring.
+- Activity heatmap redesigned as a GitHub-style year-navigable grid.
+  Rows represent days of the week (Monday–Sunday); columns represent
+  calendar weeks. Year tabs derived from the analysis window allow
+  switching between calendar years without regenerating the report.
+  A contributor dropdown provides per-contributor views alongside the
+  default aggregated view. Leap years are handled correctly through
+  UTC-based date arithmetic. The four-spec embed (daily/weekly/monthly/
+  yearly) is replaced by a single compact daily-count JSON payload,
+  reducing embedded heatmap data size proportional to the number of
+  years in the analysis window.
 
 ### Fixed
 
@@ -32,6 +42,16 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   Reveille attempted to render help output — including on bare `reveille`
   invocations due to `no_args_is_help=True`. Typer 0.18.0 restores full
   Click 8.3.x compatibility.
+
+### Removed
+- `--heatmap-granularity` CLI flag removed. The concept of switching
+  between weekly/monthly/yearly chart structures is superseded by year
+  navigation within a single canonical grid layout.
+- `heatmap_granularity` TOML key removed from `ReportConfig` and the
+  `[report]` section of `reveille.toml`. Existing configuration files
+  containing this key are unaffected — the key is silently ignored by
+  the TOML parser.
+- `HeatmapGranularity` type alias removed from `reveille.domain.models`.
 
 ---
 

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -10,8 +10,12 @@ script block. Client-side initialisation renders all charts via
 Plotly.newPlot() at page load, applying the active colour theme at
 that time. On theme toggle, Plotly.relayout() updates each chart's
 background, axis, and font properties without re-fetching trace data.
-This strategy supports complete dark mode parity for all charts
-without doubling the embedded payload.
+
+The activity heatmap uses a compact daily-count payload rather than
+a pre-built Plotly spec. The client builds the GitHub-style 7-row
+grid (Mon-Sun rows, calendar-week columns) from the raw counts,
+allowing year and contributor navigation via Plotly.react() without
+re-fetching data from the server.
 
 The string "</script>" is escaped as "<\/script>" in all JSON
 output to prevent premature script block termination when chart
@@ -38,7 +42,6 @@ from jinja2 import (
 
 from reveille.domain.models import (
     Commit,
-    HeatmapGranularity,
     RankedContributor,
     ReportData,
 )
@@ -62,7 +65,6 @@ _PIE_PALETTE: list[str] = [
     "#6366f1",
     "#f97316",
 ]
-
 
 # Module-level cache for the Plotly JS bundle.
 # plotly.offline.get_plotlyjs() reads ~3.5 MB of minified JavaScript from
@@ -99,19 +101,12 @@ class Renderer:
         self,
         data: ReportData,
         output_path: Path,
-        heatmap_granularity: HeatmapGranularity = "monthly",
     ) -> Path:
         """Render the report and write it to the specified output path.
 
         Args:
             data: The complete structured report dataset.
             output_path: Destination path for the HTML file.
-            heatmap_granularity: Resolution of the commit activity heatmap.
-                'weekly' renders one column per calendar week. 'monthly'
-                renders one column per calendar month with weekday rows.
-                'yearly' renders one column per year with month rows.
-                Defaults to 'monthly', which balances detail and readability
-                for repositories with more than six months of history.
 
         Returns:
             The absolute path of the written file.
@@ -139,7 +134,6 @@ class Renderer:
                 derived=derived,
                 plotly_js=plotly_js,
                 generated_at=generated_at,
-                heatmap_granularity=heatmap_granularity,
             )
         except RenderError:
             raise
@@ -187,26 +181,27 @@ class Renderer:
 
         Each returned value is a Plotly figure serialised as a JSON string,
         suitable for embedding in an application/json script block and
-        rendered client-side via Plotly.newPlot(). Returns the JSON
-        string 'null' for any chart that lacks sufficient data.
+        rendered client-side via Plotly.newPlot(). Returns the JSON string
+        'null' for any chart that lacks sufficient data.
+
+        The heatmap key contains a compact daily-count payload rather than
+        a Plotly spec. The client builds the GitHub-style grid from this
+        data, navigating between years and contributors via Plotly.react().
 
         Args:
             data: The complete report dataset.
 
         Returns:
-            A dict mapping chart identifier to Plotly JSON specification string.
-            The heatmap is provided as four separate keys (heatmap_daily,
-            heatmap_weekly, heatmap_monthly, heatmap_yearly) to support
-            client-side granularity toggling without a page reload.
+            A dict mapping chart identifier to JSON string.
         """
         return {
             "timeline": _build_timeline_chart(data.commits),
-            "heatmap_daily": _build_heatmap_chart(
-                data.commits, "daily", window_end=data.metadata.analysis_until
+            "heatmap": _build_heatmap_data(
+                data.commits,
+                data.ranked_contributors,
+                data.metadata.analysis_since,
+                data.metadata.analysis_until,
             ),
-            "heatmap_weekly": _build_heatmap_chart(data.commits, "weekly"),
-            "heatmap_monthly": _build_heatmap_chart(data.commits, "monthly"),
-            "heatmap_yearly": _build_heatmap_chart(data.commits, "yearly"),
             "contributor_commits": _build_contributor_commits_chart(data.ranked_contributors),
             "contributor_lines": _build_contributor_lines_chart(data.ranked_contributors),
             "pie_commits": _build_commit_share_pie(data.ranked_contributors),
@@ -268,308 +263,65 @@ def _build_timeline_chart(commits: list[Commit]) -> str:
     return _to_json(fig)
 
 
-def _build_heatmap_chart(
+def _build_heatmap_data(
     commits: list[Commit],
-    granularity: HeatmapGranularity,
-    window_end: datetime.date | None = None,
+    ranked_contributors: list[RankedContributor],
+    analysis_since: datetime.date,
+    analysis_until: datetime.date,
 ) -> str:
-    """Build a commit activity heatmap at the specified granularity.
+    """Build a compact daily commit-count payload for client-side heatmap rendering.
 
-    Dispatches to the appropriate granularity-specific builder. Each
-    builder produces a heatmap with a different time bucketing strategy
-    suited to the volume of history being visualised.
+    The payload contains three keys:
+    - years: integer list covering analysis_since.year through analysis_until.year
+    - contributors: ordered list of {email, name} dicts; "__aggregated__" is always
+      first, followed by contributors in ranked order
+    - daily_counts: dict keyed by email (including "__aggregated__") mapping
+      ISO 8601 date strings to integer commit counts for that calendar day
+
+    The client builds the GitHub-style grid (7 rows Mon-Sun, calendar-week columns)
+    from this data. Year tabs and a contributor dropdown drive Plotly.react() calls
+    without re-fetching or recomputing server-side data.
 
     Args:
         commits: All commits in the analysis window.
-        granularity: One of 'daily', 'weekly', 'monthly', or 'yearly'.
-        window_end: End date of the analysis window. Required for the daily
-            granularity to anchor the rolling window cap. When None and
-            granularity is 'daily', the maximum commit date is used.
+        ranked_contributors: Contributor list in rank order, used to determine
+            the dropdown ordering and to key per-contributor counts.
+        analysis_since: Start of the analysis window.
+        analysis_until: End of the analysis window.
 
     Returns:
-        A Plotly figure JSON string, or 'null' if commits is empty.
+        A JSON string safe for embedding in an application/json script block.
+        The sentinel sequence "</" is escaped to prevent premature script
+        block termination.
     """
-    if not commits:
-        return "null"
-    if granularity == "daily":
-        effective_end = (
-            window_end if window_end is not None else max(c.timestamp.date() for c in commits)
-        )
-        return _build_heatmap_daily(commits, effective_end)
-    if granularity == "weekly":
-        return _build_heatmap_weekly(commits)
-    if granularity == "monthly":
-        return _build_heatmap_monthly(commits)
-    return _build_heatmap_yearly(commits)
+    years = list(range(analysis_since.year, analysis_until.year + 1))
 
-
-def _build_heatmap_weekly(commits: list[Commit]) -> str:
-    """Build a calendar-style weekly heatmap.
-
-    Rows represent days of the week (Monday to Sunday). Columns represent
-    calendar weeks across the analysis window. Best suited for repositories
-    with fewer than six months of history.
-
-    Args:
-        commits: All commits in the analysis window. Must be non-empty.
-
-    Returns:
-        A Plotly figure JSON string.
-    """
-    earliest = min(c.timestamp.date() for c in commits)
-    base_week = earliest - datetime.timedelta(days=earliest.weekday())
-    cell: dict[tuple[int, int], int] = defaultdict(int)
-    week_indices: set[int] = set()
+    agg_counts: defaultdict[str, int] = defaultdict(int)
+    per_email: dict[str, defaultdict[str, int]] = {}
 
     for commit in commits:
-        d = commit.timestamp.date()
-        week_start = d - datetime.timedelta(days=d.weekday())
-        week_idx = (week_start - base_week).days // 7
-        cell[(week_idx, d.weekday())] += 1
-        week_indices.add(week_idx)
+        date_str = commit.timestamp.date().isoformat()
+        agg_counts[date_str] += 1
+        email_key = commit.author_email.lower()
+        if email_key not in per_email:
+            per_email[email_key] = defaultdict(int)
+        per_email[email_key][date_str] += 1
 
-    num_weeks = max(week_indices) + 1
-    z = [[cell.get((w, day), 0) for w in range(num_weeks)] for day in range(7)]
-    week_labels = [
-        (base_week + datetime.timedelta(weeks=w)).strftime("%b %d") for w in range(num_weeks)
-    ]
-    day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    contributors: list[dict[str, str]] = [{"email": "__aggregated__", "name": "All Contributors"}]
+    daily_counts: dict[str, dict[str, int]] = {"__aggregated__": dict(agg_counts)}
 
-    fig = go.Figure(
-        go.Heatmap(
-            z=z,
-            x=week_labels,
-            y=day_labels,
-            colorscale=_heatmap_colorscale(),
-            showscale=True,
-            hovertemplate="Week: %{x}<br>Day: %{y}<br>Commits: %{z}<extra></extra>",
-        )
-    )
-    layout = _base_layout()
-    layout["xaxis"] = {
-        "type": "category",
-        "gridcolor": "#30363d",
-        "linecolor": "#30363d",
+    for r in ranked_contributors:
+        email_key = r.stats.email.lower()
+        if email_key in per_email:
+            contributors.append({"email": email_key, "name": r.stats.name})
+            daily_counts[email_key] = dict(per_email[email_key])
+
+    payload: dict[str, object] = {
+        "years": years,
+        "contributors": contributors,
+        "daily_counts": daily_counts,
     }
-    layout["yaxis"] = {
-        "autorange": "reversed",
-        "gridcolor": "#30363d",
-        "scaleanchor": "x",
-        "constrain": "domain",
-    }
-    fig.update_layout(**layout, height=260)
-    return _to_json(fig)
-
-
-def _build_heatmap_monthly(commits: list[Commit]) -> str:
-    """Build a monthly commit activity heatmap.
-
-    Rows represent days of the week (Monday to Sunday). Columns represent
-    calendar months labelled as YYYY-MM. Each cell contains the total
-    commit count for that weekday across all occurrences within that
-    calendar month. Suitable for repositories with six months to three
-    years of history.
-
-    Args:
-        commits: All commits in the analysis window. Must be non-empty.
-
-    Returns:
-        A Plotly figure JSON string.
-    """
-    cell: dict[tuple[str, int], int] = defaultdict(int)
-    months_set: set[str] = set()
-
-    for commit in commits:
-        d = commit.timestamp.date()
-        month_key = f"{d.year:04d}-{d.month:02d}"
-        cell[(month_key, d.weekday())] += 1
-        months_set.add(month_key)
-
-    sorted_months = sorted(months_set)
-    day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-    z = [[cell.get((month, day), 0) for month in sorted_months] for day in range(7)]
-
-    fig = go.Figure(
-        go.Heatmap(
-            z=z,
-            x=sorted_months,
-            y=day_labels,
-            colorscale=_heatmap_colorscale(),
-            showscale=True,
-            hovertemplate="Month: %{x}<br>Day: %{y}<br>Commits: %{z}<extra></extra>",
-        )
-    )
-    layout = _base_layout()
-    layout["xaxis"] = {
-        "type": "category",
-        "gridcolor": "#30363d",
-        "linecolor": "#30363d",
-    }
-    layout["yaxis"] = {
-        "autorange": "reversed",
-        "gridcolor": "#30363d",
-        "scaleanchor": "x",
-        "constrain": "domain",
-    }
-    fig.update_layout(**layout, height=260)
-    return _to_json(fig)
-
-
-def _build_heatmap_yearly(commits: list[Commit]) -> str:
-    """Build a yearly commit activity heatmap.
-
-    Rows represent months of the year (January to December). Columns
-    represent calendar years. Each cell contains the total commit count
-    for that month-year combination. Suitable for repositories with more
-    than three years of history.
-
-    Args:
-        commits: All commits in the analysis window. Must be non-empty.
-
-    Returns:
-        A Plotly figure JSON string.
-    """
-    cell: dict[tuple[int, int], int] = defaultdict(int)
-    years_set: set[int] = set()
-
-    for commit in commits:
-        d = commit.timestamp.date()
-        cell[(d.year, d.month)] += 1
-        years_set.add(d.year)
-
-    sorted_years = sorted(years_set)
-    month_labels = [
-        "Jan",
-        "Feb",
-        "Mar",
-        "Apr",
-        "May",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Oct",
-        "Nov",
-        "Dec",
-    ]
-    z = [[cell.get((year, month + 1), 0) for year in sorted_years] for month in range(12)]
-
-    fig = go.Figure(
-        go.Heatmap(
-            z=z,
-            x=[str(y) for y in sorted_years],
-            y=month_labels,
-            colorscale=_heatmap_colorscale(),
-            showscale=True,
-            hovertemplate="Year: %{x}<br>Month: %{y}<br>Commits: %{z}<extra></extra>",
-        )
-    )
-    layout = _base_layout()
-    layout["xaxis"] = {
-        "type": "category",
-        "gridcolor": "#30363d",
-        "linecolor": "#30363d",
-    }
-    layout["yaxis"] = {
-        "autorange": "reversed",
-        "gridcolor": "#30363d",
-        "scaleanchor": "x",
-        "constrain": "domain",
-    }
-    fig.update_layout(**layout, height=340)
-    return _to_json(fig)
-
-
-def _build_heatmap_daily(
-    commits: list[Commit],
-    window_end: datetime.date,
-    max_days: int = 365,
-) -> str:
-    """Build a GitHub-style daily commit activity heatmap.
-
-    Rows represent days of the week (Monday to Sunday). Columns represent
-    calendar weeks within the rolling window. Each cell contains the exact
-    commit count for that specific calendar day — no aggregation occurs
-    within a week, unlike the weekly granularity builder.
-
-    The rolling window is capped at max_days before window_end to prevent
-    excessive chart width for repositories with multi-year histories.
-
-    Args:
-        commits: All commits in the analysis window.
-        window_end: End date of the analysis window. Used as the anchor for
-            the rolling window cap.
-        max_days: Maximum calendar days to display counting back from
-            window_end. Defaults to 365 (one rolling year).
-
-    Returns:
-        A Plotly figure JSON string, or 'null' if no commits fall within
-        the rolling window.
-    """
-    if not commits:
-        return "null"
-
-    rolling_start = window_end - datetime.timedelta(days=max_days - 1)
-    filtered = [c for c in commits if c.timestamp.date() >= rolling_start]
-    if not filtered:
-        return "null"
-
-    date_counts: dict[datetime.date, int] = defaultdict(int)
-    for commit in filtered:
-        date_counts[commit.timestamp.date()] += 1
-
-    # Align the grid to the Monday of the week containing rolling_start.
-    base_monday = rolling_start - datetime.timedelta(days=rolling_start.weekday())
-    last_monday = window_end - datetime.timedelta(days=window_end.weekday())
-    num_weeks = (last_monday - base_monday).days // 7 + 1
-
-    z: list[list[int]] = []
-    customdata: list[list[str]] = []
-    for day in range(7):
-        row_z: list[int] = []
-        row_dates: list[str] = []
-        for week in range(num_weeks):
-            date = base_monday + datetime.timedelta(weeks=week, days=day)
-            if rolling_start <= date <= window_end:
-                row_z.append(date_counts.get(date, 0))
-                row_dates.append(date.strftime("%Y-%m-%d"))
-            else:
-                row_z.append(0)
-                row_dates.append("")
-        z.append(row_z)
-        customdata.append(row_dates)
-
-    week_labels = [
-        (base_monday + datetime.timedelta(weeks=w)).strftime("%b %d") for w in range(num_weeks)
-    ]
-    day_labels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-
-    fig = go.Figure(
-        go.Heatmap(
-            z=z,
-            x=week_labels,
-            y=day_labels,
-            customdata=customdata,
-            colorscale=_heatmap_colorscale(),
-            showscale=True,
-            hovertemplate="%{customdata}<br>Commits: %{z}<extra></extra>",
-        )
-    )
-    layout = _base_layout()
-    layout["xaxis"] = {
-        "type": "category",
-        "gridcolor": "#30363d",
-        "linecolor": "#30363d",
-        "tickangle": -45,
-    }
-    layout["yaxis"] = {
-        "autorange": "reversed",
-        "gridcolor": "#30363d",
-        "scaleanchor": "x",
-        "constrain": "domain",
-    }
-    fig.update_layout(**layout, height=260)
-    return _to_json(fig)
+    return json.dumps(payload).replace("</", "<\\/")
 
 
 def _build_contributor_commits_chart(ranked: list[RankedContributor]) -> str:
@@ -843,24 +595,6 @@ def _pie_colors(n: int) -> list[str]:
         A list of n hex colour strings.
     """
     return [_PIE_PALETTE[i % len(_PIE_PALETTE)] for i in range(n)]
-
-
-def _heatmap_colorscale() -> list[list[float | str]]:
-    """Return the Plotly colorscale for all heatmap variants.
-
-    Zero-value cells are fully transparent, which renders as the page
-    background colour in both light and dark modes without requiring
-    a separate theme-specific colorscale.
-
-    Returns:
-        A list of [position, colour] pairs in Plotly colorscale format.
-    """
-    return [
-        [0.0, "rgba(0, 0, 0, 0)"],
-        [0.001, "#bfdbfe"],
-        [0.35, "#3b82f6"],
-        [1.0, "#1e3a8a"],
-    ]
 
 
 # ------------------------------------------------------------------

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -181,7 +181,6 @@ def _merge_cli_flags(
     exclude_author: list[str] | None,
     min_commits: int | None,
     no_ranking: bool,
-    heatmap_granularity: str | None,
 ) -> dict[str, object]:
     """Merge CLI flag values into the base configuration dict.
 
@@ -227,8 +226,6 @@ def _merge_cli_flags(
         merged["min_commits"] = min_commits
     if no_ranking:
         merged["ranking_enabled"] = False
-    if heatmap_granularity is not None:
-        merged["heatmap_granularity"] = heatmap_granularity
 
     return merged
 
@@ -274,16 +271,6 @@ def generate(
         bool,
         typer.Option("--no-ranking", help="Omit the contributor ranking table from the output."),
     ] = False,
-    heatmap_granularity: Annotated[
-        str | None,
-        typer.Option(
-            "--heatmap-granularity",
-            help=(
-                "Heatmap resolution. 'weekly' suits short histories. "
-                "'monthly' is the default. 'yearly' suits long histories."
-            ),
-        ),
-    ] = None,
     config: Annotated[
         Path | None,
         typer.Option("--config", "-c", help="Path to a TOML configuration file."),
@@ -323,7 +310,6 @@ def generate(
         exclude_author,
         min_commits,
         no_ranking,
-        heatmap_granularity,
     )
 
     try:

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 import datetime
 import tomllib
 from pathlib import Path
-from typing import Any, get_args
+from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
-from reveille.domain.models import HeatmapGranularity
 from reveille.exceptions import ConfigurationError
 
 
@@ -71,15 +70,6 @@ class ReportConfig(BaseModel):
     min_commits: int = Field(default=1, ge=1)
     ranking_enabled: bool = Field(default=True)
     ranking_weights: RankingWeights = Field(default_factory=RankingWeights)
-    heatmap_granularity: HeatmapGranularity = Field(
-        default="monthly",
-        description=(
-            "Resolution of the commit activity heatmap. "
-            "'weekly' suits repositories with fewer than six months of history. "
-            "'monthly' is the default and suits most repositories. "
-            "'yearly' suits repositories with more than three years of history."
-        ),
-    )
 
     @model_validator(mode="after")
     def since_must_precede_until(self) -> ReportConfig:
@@ -157,14 +147,6 @@ def _parse_report_section(report: dict[str, Any]) -> dict[str, Any]:
                     f"Invalid '{field}' date in configuration file: "
                     f"'{report[field]}'. Expected YYYY-MM-DD."
                 ) from exc
-    if "heatmap_granularity" in report:
-        val = str(report["heatmap_granularity"])
-        if val not in get_args(HeatmapGranularity):
-            raise ConfigurationError(
-                f"Invalid heatmap_granularity '{val}' in configuration file. "
-                f"Must be one of: {', '.join(get_args(HeatmapGranularity))}."
-            )
-        kwargs["heatmap_granularity"] = val
     return kwargs
 
 

--- a/src/reveille/domain/models.py
+++ b/src/reveille/domain/models.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass, field
-from typing import Literal, TypeAlias
-
-HeatmapGranularity: TypeAlias = Literal["daily", "weekly", "monthly", "yearly"]
 
 
 @dataclass(frozen=True)

--- a/src/reveille/init.py
+++ b/src/reveille/init.py
@@ -56,17 +56,6 @@ _DEFAULT_CONFIG_TEMPLATE: str = """\
 # Defaults to today.
 # until = "2024-12-31"
 
-# Resolution of the commit activity heatmap.
-# Accepted values: "daily", "weekly", "monthly", "yearly"
-#   daily   -- one cell per calendar day (GitHub-style). Rolling 365-day window.
-#              Best for active repositories where per-day granularity is meaningful.
-#   weekly  -- one column per calendar week.
-#              Best for repositories with fewer than 6 months of history.
-#   monthly -- one column per calendar month. Default. Suits most repositories.
-#   yearly  -- one column per year.
-#              Best for repositories with more than 3 years of history.
-# heatmap_granularity = "monthly"
-
 
 # ------------------------------------------------------------------------------
 # [filters] -- Contributor and commit filtering

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -113,4 +113,4 @@ def generate_report(
     if on_progress is not None:
         on_progress("Rendering report")
     renderer = Renderer()
-    return renderer.render(report_data, config.output_path, config.heatmap_granularity)
+    return renderer.render(report_data, config.output_path)

--- a/src/reveille/templates/report.html.j2
+++ b/src/reveille/templates/report.html.j2
@@ -428,13 +428,20 @@
         /* ============================================================
            Heatmap Granularity Toolbar
            ============================================================ */
-        .heatmap-toolbar {
+        .heatmap-controls {
             display: flex;
-            gap: 6px;
+            align-items: center;
+            gap: 12px;
             margin-bottom: 12px;
+            flex-wrap: wrap;
         }
 
-        .heatmap-toggle-btn {
+        .heatmap-year-tabs {
+            display: flex;
+            gap: 6px;
+        }
+
+        .heatmap-year-btn {
             padding: 4px 12px;
             background: var(--color-surface);
             border: 1px solid var(--color-border);
@@ -444,7 +451,6 @@
             font-size: 11px;
             font-weight: 700;
             letter-spacing: 0.6px;
-            text-transform: uppercase;
             cursor: pointer;
             transition:
                 background-color 0.15s ease,
@@ -452,16 +458,31 @@
                 border-color 0.15s ease;
         }
 
-        .heatmap-toggle-btn:hover {
+        .heatmap-year-btn:hover,
+        .heatmap-year-btn.heatmap-year-active {
             background: var(--color-primary-dim);
             border-color: var(--color-primary);
             color: var(--color-primary);
         }
 
-        .heatmap-toggle-btn.heatmap-toggle-active {
-            background: var(--color-primary-dim);
+        .heatmap-contributor-select {
+            padding: 4px 10px;
+            background: var(--color-surface);
+            border: 1px solid var(--color-border);
+            border-radius: 4px;
+            color: var(--color-text-secondary);
+            font-family: inherit;
+            font-size: 11px;
+            font-weight: 600;
+            cursor: pointer;
+            min-width: 160px;
+            transition:
+                background-color 0.15s ease,
+                border-color 0.15s ease;
+        }
+
+        .heatmap-contributor-select:hover {
             border-color: var(--color-primary);
-            color: var(--color-primary);
         }
     </style>
 </head>
@@ -529,19 +550,10 @@
          ============================================================ -->
     <div class="section">
         <h2 class="section-title">Commit Activity Heatmap</h2>
-        <div class="heatmap-toolbar">
-            <button id="heatmap-toggle-daily"
-                    class="heatmap-toggle-btn{% if heatmap_granularity == 'daily' %} heatmap-toggle-active{% endif %}"
-                    type="button">Daily</button>
-            <button id="heatmap-toggle-weekly"
-                    class="heatmap-toggle-btn{% if heatmap_granularity == 'weekly' %} heatmap-toggle-active{% endif %}"
-                    type="button">Weekly</button>
-            <button id="heatmap-toggle-monthly"
-                    class="heatmap-toggle-btn{% if heatmap_granularity == 'monthly' %} heatmap-toggle-active{% endif %}"
-                    type="button">Monthly</button>
-            <button id="heatmap-toggle-yearly"
-                    class="heatmap-toggle-btn{% if heatmap_granularity == 'yearly' %} heatmap-toggle-active{% endif %}"
-                    type="button">Yearly</button>
+        <div class="heatmap-controls">
+            <div id="heatmap-year-tabs" class="heatmap-year-tabs"></div>
+            <select id="heatmap-contributor-select"
+                    class="heatmap-contributor-select"></select>
         </div>
         <div class="chart-container">
             <div id="chart-heatmap"></div>
@@ -707,17 +719,8 @@
 <script type="application/json" id="spec-timeline">
 {{ charts.timeline | safe }}
 </script>
-<script type="application/json" id="spec-heatmap-weekly">
-{{ charts.heatmap_weekly | safe }}
-</script>
-<script type="application/json" id="spec-heatmap-monthly">
-{{ charts.heatmap_monthly | safe }}
-</script>
-<script type="application/json" id="spec-heatmap-yearly">
-{{ charts.heatmap_yearly | safe }}
-</script>
-<script type="application/json" id="spec-heatmap-daily">
-{{ charts.heatmap_daily | safe }}
+<script type="application/json" id="spec-heatmap">
+{{ charts.heatmap | safe }}
 </script>
 <script type="application/json" id="spec-contributor_commits">
 {{ charts.contributor_commits | safe }}
@@ -741,8 +744,6 @@
 
     var THEME_KEY = 'reveille-theme';
 
-    // Non-heatmap charts only. The heatmap is managed separately
-    // to support client-side granularity switching.
     var CHART_IDS = [
         'timeline',
         'contributor_commits',
@@ -750,13 +751,6 @@
         'pie_commits',
         'pie_lines'
     ];
-
-    var HEATMAP_GRANULARITIES = ['daily', 'weekly', 'monthly', 'yearly'];
-
-    // Tracks the currently rendered heatmap granularity.
-    // Initialised from the value set by --heatmap-granularity at report
-    // generation time, which controls the default view on open.
-    var currentHeatmapGranularity = '{{ heatmap_granularity }}';
 
     var PLOTLY_CONFIG = {
         responsive: true,
@@ -786,36 +780,33 @@
         }
     };
 
+    // Heatmap state — populated during DOMContentLoaded.
+    var heatmapData = null;
+    var currentYear = null;
+    var currentContributor = '__aggregated__';
+
     // ------------------------------------------------------------------
     // Theme persistence
     // ------------------------------------------------------------------
 
     function readTheme() {
-        try {
-            return localStorage.getItem(THEME_KEY) || 'light';
-        } catch (e) {
-            return 'light';
-        }
+        try { return localStorage.getItem(THEME_KEY) || 'light'; }
+        catch (e) { return 'light'; }
     }
 
     function writeTheme(theme) {
-        try {
-            localStorage.setItem(THEME_KEY, theme);
-        } catch (e) {
-            // localStorage unavailable (strict private browsing). Non-fatal.
-        }
+        try { localStorage.setItem(THEME_KEY, theme); }
+        catch (e) { /* localStorage unavailable — non-fatal */ }
     }
 
     // ------------------------------------------------------------------
-    // Document theme application
+    // Document theme
     // ------------------------------------------------------------------
 
     function applyThemeToDocument(theme) {
         document.documentElement.setAttribute('data-theme', theme);
         var btn = document.getElementById('theme-toggle');
-        if (btn) {
-            btn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
-        }
+        if (btn) btn.textContent = theme === 'dark' ? 'Light Mode' : 'Dark Mode';
     }
 
     // ------------------------------------------------------------------
@@ -835,9 +826,8 @@
         }
 
         var spec;
-        try {
-            spec = JSON.parse(raw);
-        } catch (e) {
+        try { spec = JSON.parse(raw); }
+        catch (e) {
             divEl.innerHTML =
                 '<p class="chart-empty">Chart specification could not be parsed.</p>';
             return;
@@ -855,78 +845,197 @@
 
     function initAllCharts(theme) {
         CHART_IDS.forEach(function (id) { initChart(id, theme); });
-        initHeatmap(currentHeatmapGranularity, theme);
+        initHeatmapControls(theme);
     }
 
     // ------------------------------------------------------------------
-    // Heatmap initialisation and granularity toggle
+    // Heatmap: GitHub-style grid builder
+    //
+    // All date arithmetic uses UTC milliseconds to avoid DST anomalies.
+    // The grid spans from the Monday of Jan 1's week to the Sunday of
+    // Dec 31's week for the requested year. Cells outside the calendar
+    // year render as zero (transparent via the colorscale) with empty
+    // customdata so hover is suppressed.
     // ------------------------------------------------------------------
 
-    function _loadHeatmapSpec(granularity) {
-        var specEl = document.getElementById('spec-heatmap-' + granularity);
-        if (!specEl) return null;
-        var raw = specEl.textContent.trim();
-        if (!raw || raw === 'null') return null;
-        try {
-            return JSON.parse(raw);
-        } catch (e) {
-            return null;
+    function buildYearGrid(year, counts) {
+        var jan1Ms  = Date.UTC(year, 0, 1);
+        var dec31Ms = Date.UTC(year, 11, 31);
+
+        // Convert JS Sunday=0 to Monday=0 day-of-week index.
+        var jan1Dow  = (new Date(jan1Ms).getUTCDay() + 6) % 7;
+        var dec31Dow = (new Date(dec31Ms).getUTCDay() + 6) % 7;
+
+        var gridStartMs = jan1Ms  - jan1Dow  * 86400000;
+        var gridEndMs   = dec31Ms + (6 - dec31Dow) * 86400000;
+
+        // gridStart is always Monday, gridEnd always Sunday —
+        // total days is always divisible by 7.
+        var numWeeks = Math.round(
+            (gridEndMs - gridStartMs) / 86400000 + 1
+        ) / 7;
+
+        var MONTHS = [
+            'Jan','Feb','Mar','Apr','May','Jun',
+            'Jul','Aug','Sep','Oct','Nov','Dec'
+        ];
+        var DAY_LABELS = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+
+        var z = [], customdata = [], xLabels = [];
+        for (var d = 0; d < 7; d++) { z.push([]); customdata.push([]); }
+
+        for (var w = 0; w < numWeeks; w++) {
+            var weekMonMs = gridStartMs + w * 7 * 86400000;
+            var wm = new Date(weekMonMs);
+            xLabels.push(
+                MONTHS[wm.getUTCMonth()] + ' ' +
+                String(wm.getUTCDate()).padStart(2, '0')
+            );
+
+            for (var d = 0; d < 7; d++) {
+                var cellMs = weekMonMs + d * 86400000;
+                var cd = new Date(cellMs);
+                if (cd.getUTCFullYear() === year) {
+                    var mo = String(cd.getUTCMonth() + 1).padStart(2, '0');
+                    var da = String(cd.getUTCDate()).padStart(2, '0');
+                    var dateStr = year + '-' + mo + '-' + da;
+                    z[d].push(counts[dateStr] || 0);
+                    customdata[d].push(dateStr);
+                } else {
+                    // Outside the calendar year — render transparent.
+                    z[d].push(0);
+                    customdata[d].push('');
+                }
+            }
         }
+
+        return { z: z, x: xLabels, y: DAY_LABELS, customdata: customdata };
     }
 
-    function initHeatmap(granularity, theme) {
+    // ------------------------------------------------------------------
+    // Heatmap rendering
+    // ------------------------------------------------------------------
+
+    function renderHeatmap(year, email, theme) {
         var divEl = document.getElementById('chart-heatmap');
-        if (!divEl) return;
+        if (!divEl || !heatmapData) return;
 
-        var spec = _loadHeatmapSpec(granularity);
-        if (!spec || !spec.data || spec.data.length === 0) {
-            divEl.innerHTML =
-                '<p class="chart-empty">Insufficient data for this view.</p>';
-            return;
-        }
+        var counts = heatmapData.daily_counts[email] || {};
+        var grid   = buildYearGrid(year, counts);
 
-        var layout = Object.assign({}, spec.layout || {}, THEME_LAYOUTS[theme]);
-        Plotly.newPlot(divEl, spec.data, layout, PLOTLY_CONFIG);
-    }
+        var trace = {
+            type: 'heatmap',
+            z: grid.z,
+            x: grid.x,
+            y: grid.y,
+            customdata: grid.customdata,
+            colorscale: [
+                [0.0,   'rgba(0,0,0,0)'],
+                [0.001, '#bfdbfe'],
+                [0.35,  '#3b82f6'],
+                [1.0,   '#1e3a8a']
+            ],
+            showscale: true,
+            hovertemplate: '%{customdata}<br>Commits: %{z}<extra></extra>'
+        };
 
-    function switchHeatmap(granularity) {
-        if (granularity === currentHeatmapGranularity) return;
-
-        var divEl = document.getElementById('chart-heatmap');
-        if (!divEl) return;
-
-        var spec = _loadHeatmapSpec(granularity);
-        if (!spec || !spec.data || spec.data.length === 0) {
-            divEl.innerHTML =
-                '<p class="chart-empty">Insufficient data for this view.</p>';
-            currentHeatmapGranularity = granularity;
-            _updateHeatmapButtons(granularity);
-            return;
-        }
-
-        var theme = readTheme();
-        var layout = Object.assign({}, spec.layout || {}, THEME_LAYOUTS[theme]);
+        var layout = Object.assign({}, {
+            font: {
+                family: "-apple-system, BlinkMacSystemFont, 'Segoe UI', " +
+                        "Roboto, 'Helvetica Neue', Arial, sans-serif",
+                size: 12
+            },
+            margin:     { l: 60, r: 30, t: 20, b: 50 },
+            xaxis:      { type: 'category', tickangle: -45 },
+            yaxis:      { autorange: 'reversed', scaleanchor: 'x',
+                          constrain: 'domain' },
+            showlegend: false,
+            modebar:    { remove: ['logo'] },
+            height:     260
+        }, THEME_LAYOUTS[theme]);
 
         if (divEl._fullLayout) {
-            Plotly.react(divEl, spec.data, layout, PLOTLY_CONFIG);
+            Plotly.react(divEl, [trace], layout, PLOTLY_CONFIG);
         } else {
-            Plotly.newPlot(divEl, spec.data, layout, PLOTLY_CONFIG);
+            Plotly.newPlot(divEl, [trace], layout, PLOTLY_CONFIG);
         }
-
-        currentHeatmapGranularity = granularity;
-        _updateHeatmapButtons(granularity);
     }
 
-    function _updateHeatmapButtons(granularity) {
-        HEATMAP_GRANULARITIES.forEach(function (g) {
-            var btn = document.getElementById('heatmap-toggle-' + g);
-            if (!btn) return;
-            if (g === granularity) {
-                btn.classList.add('heatmap-toggle-active');
+    // ------------------------------------------------------------------
+    // Heatmap controls initialisation
+    // ------------------------------------------------------------------
+
+    function initHeatmapControls(theme) {
+        var specEl = document.getElementById('spec-heatmap');
+        if (!specEl) return;
+
+        var raw = specEl.textContent.trim();
+        if (!raw || raw === 'null') {
+            var divEl = document.getElementById('chart-heatmap');
+            if (divEl) divEl.innerHTML =
+                '<p class="chart-empty">Insufficient data for this view.</p>';
+            return;
+        }
+
+        try { heatmapData = JSON.parse(raw); }
+        catch (e) { return; }
+
+        var years        = heatmapData.years        || [];
+        var contributors = heatmapData.contributors || [];
+
+        // Default: most recent year, aggregated view.
+        currentYear        = years[years.length - 1];
+        currentContributor = '__aggregated__';
+
+        // Build year tab buttons.
+        var tabsEl = document.getElementById('heatmap-year-tabs');
+        if (tabsEl) {
+            tabsEl.innerHTML = '';
+            years.forEach(function (yr) {
+                var btn = document.createElement('button');
+                btn.type      = 'button';
+                btn.textContent = String(yr);
+                btn.className = 'heatmap-year-btn' +
+                    (yr === currentYear ? ' heatmap-year-active' : '');
+                btn.addEventListener('click', function () {
+                    currentYear = yr;
+                    tabsEl.querySelectorAll('.heatmap-year-btn')
+                        .forEach(function (b) {
+                            b.classList.toggle(
+                                'heatmap-year-active',
+                                b.textContent === String(yr)
+                            );
+                        });
+                    renderHeatmap(currentYear, currentContributor, readTheme());
+                });
+                tabsEl.appendChild(btn);
+            });
+        }
+
+        // Build contributor dropdown.
+        var selectEl = document.getElementById('heatmap-contributor-select');
+        if (selectEl) {
+            if (contributors.length > 1) {
+                selectEl.innerHTML = '';
+                contributors.forEach(function (c) {
+                    var opt       = document.createElement('option');
+                    opt.value     = c.email;
+                    opt.textContent = c.name;
+                    selectEl.appendChild(opt);
+                });
+                selectEl.value = '__aggregated__';
+                selectEl.style.display = '';
+                selectEl.addEventListener('change', function () {
+                    currentContributor = selectEl.value;
+                    renderHeatmap(currentYear, currentContributor, readTheme());
+                });
             } else {
-                btn.classList.remove('heatmap-toggle-active');
+                // Single contributor: dropdown provides no choice — hide it.
+                selectEl.style.display = 'none';
             }
-        });
+        }
+
+        renderHeatmap(currentYear, currentContributor, theme);
     }
 
     // ------------------------------------------------------------------
@@ -947,7 +1056,7 @@
     }
 
     // ------------------------------------------------------------------
-    // Toggle handler
+    // Theme toggle
     // ------------------------------------------------------------------
 
     function toggleTheme() {
@@ -958,7 +1067,7 @@
     }
 
     // ------------------------------------------------------------------
-    // Initialisation
+    // Boot
     // ------------------------------------------------------------------
 
     var initialTheme = readTheme();
@@ -966,17 +1075,8 @@
 
     document.addEventListener('DOMContentLoaded', function () {
         initAllCharts(initialTheme);
-
         var themeBtn = document.getElementById('theme-toggle');
-        if (themeBtn) {
-            themeBtn.addEventListener('click', toggleTheme);
-        }
-
-        HEATMAP_GRANULARITIES.forEach(function (g) {
-            var btn = document.getElementById('heatmap-toggle-' + g);
-            if (!btn) return;
-            btn.addEventListener('click', function () { switchHeatmap(g); });
-        });
+        if (themeBtn) themeBtn.addEventListener('click', toggleTheme);
     });
 
 }());

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -486,12 +486,9 @@ class TestGenerateCommand:
         )
         assert result.exit_code == 1
 
-    def test_output_embeds_all_four_heatmap_specs(self, default_report_content: str) -> None:
-        """All three heatmap granularity specs are present in the output."""
-        assert 'id="spec-heatmap-weekly"' in default_report_content
-        assert 'id="spec-heatmap-monthly"' in default_report_content
-        assert 'id="spec-heatmap-yearly"' in default_report_content
-        assert 'id="spec-heatmap-daily"' in default_report_content
+    def test_output_embeds_heatmap_data_spec(self, default_report_content: str) -> None:
+        """The compact heatmap data payload is embedded in the output."""
+        assert 'id="spec-heatmap"' in default_report_content
 
     def test_auto_discovers_reveille_toml_in_cwd(
         self,

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -21,11 +21,7 @@ from reveille.adapters.renderer import (
     _build_commit_share_pie,
     _build_contributor_commits_chart,
     _build_contributor_lines_chart,
-    _build_heatmap_chart,
-    _build_heatmap_daily,
-    _build_heatmap_monthly,
-    _build_heatmap_weekly,
-    _build_heatmap_yearly,
+    _build_heatmap_data,
     _build_lines_share_pie,
     _build_timeline_chart,
     _compute_bus_factor,
@@ -242,183 +238,89 @@ class TestBuildTimelineChart:
 
 
 @pytest.mark.unit
-class TestBuildHeatmapChart:
-    """Tests for the heatmap chart builder and its granularity variants."""
+class TestBuildHeatmapData:
+    """Tests for the compact heatmap daily-count payload builder."""
 
-    def test_empty_commits_returns_null_sentinel(self) -> None:
-        assert _build_heatmap_chart([], "daily") == "null"
-        assert _build_heatmap_chart([], "weekly") == "null"
-        assert _build_heatmap_chart([], "monthly") == "null"
-        assert _build_heatmap_chart([], "yearly") == "null"
-
-    def test_weekly_returns_valid_chart_json(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2024, 1, 8)),
-            _make_commit(datetime.date(2024, 1, 15)),
-        ]
-        assert _is_valid_chart_json(_build_heatmap_weekly(commits))
-
-    def test_monthly_returns_valid_chart_json(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2024, 1, 8)),
-            _make_commit(datetime.date(2024, 2, 5)),
-            _make_commit(datetime.date(2024, 3, 20)),
-        ]
-        assert _is_valid_chart_json(_build_heatmap_monthly(commits))
-
-    def test_yearly_returns_valid_chart_json(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2023, 6, 1)),
-            _make_commit(datetime.date(2024, 3, 15)),
-        ]
-        assert _is_valid_chart_json(_build_heatmap_yearly(commits))
-
-    def test_monthly_z_matrix_has_seven_rows(self) -> None:
-        """Seven rows correspond to the seven days of the week."""
-        commits = [_make_commit(datetime.date(2024, 1, d)) for d in (1, 8, 15, 22)]
-        parsed = json.loads(_build_heatmap_monthly(commits))
-        z = parsed["data"][0]["z"]
-        assert len(z) == 7
-
-    def test_yearly_z_matrix_has_twelve_rows(self) -> None:
-        """Twelve rows correspond to the twelve months of the year."""
-        commits = [_make_commit(datetime.date(2023, m, 1)) for m in range(1, 13)]
-        parsed = json.loads(_build_heatmap_yearly(commits))
-        z = parsed["data"][0]["z"]
-        assert len(z) == 12
-
-    def test_monthly_column_count_matches_distinct_months(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2024, 1, 5)),
-            _make_commit(datetime.date(2024, 3, 10)),
-        ]
-        parsed = json.loads(_build_heatmap_monthly(commits))
-        # Two distinct months: 2024-01 and 2024-03.
-        x_labels = parsed["data"][0]["x"]
-        assert len(x_labels) == 2
-
-    def test_yearly_column_count_matches_distinct_years(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2022, 6, 1)),
-            _make_commit(datetime.date(2023, 6, 1)),
-            _make_commit(datetime.date(2024, 6, 1)),
-        ]
-        parsed = json.loads(_build_heatmap_yearly(commits))
-        x_labels = parsed["data"][0]["x"]
-        assert len(x_labels) == 3
-
-    def test_dispatch_weekly_via_build_heatmap_chart(self) -> None:
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        assert _is_valid_chart_json(_build_heatmap_chart(commits, "weekly"))
-
-    def test_dispatch_monthly_via_build_heatmap_chart(self) -> None:
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        assert _is_valid_chart_json(_build_heatmap_chart(commits, "monthly"))
-
-    def test_dispatch_yearly_via_build_heatmap_chart(self) -> None:
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        assert _is_valid_chart_json(_build_heatmap_chart(commits, "yearly"))
-
-    def test_weekly_xaxis_type_is_category(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2024, 1, 8)),
-            _make_commit(datetime.date(2024, 1, 15)),
-        ]
-        result = json.loads(_build_heatmap_chart(commits, "weekly"))
-        assert result["layout"]["xaxis"]["type"] == "category"
-
-    def test_monthly_xaxis_type_is_category(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2024, 1, 8)),
-            _make_commit(datetime.date(2024, 2, 5)),
-        ]
-        result = json.loads(_build_heatmap_chart(commits, "monthly"))
-        assert result["layout"]["xaxis"]["type"] == "category"
-
-    def test_yearly_xaxis_type_is_category(self) -> None:
-        commits = [
-            _make_commit(datetime.date(2023, 6, 1)),
-            _make_commit(datetime.date(2024, 3, 15)),
-        ]
-        result = json.loads(_build_heatmap_chart(commits, "yearly"))
-        assert result["layout"]["xaxis"]["type"] == "category"
-
-
-# ------------------------------------------------------------------
-# _build_heatmap_daily
-# ------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestBuildHeatmapDaily:
-    """Tests for the GitHub-style daily heatmap builder."""
-
-    def test_empty_commits_returns_null_sentinel(self) -> None:
-        assert _build_heatmap_daily([], datetime.date(2024, 3, 31)) == "null"
-
-    def test_returns_valid_chart_json(self) -> None:
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        assert _is_valid_chart_json(_build_heatmap_daily(commits, datetime.date(2024, 1, 31)))
-
-    def test_z_matrix_has_seven_rows(self) -> None:
-        """Seven rows correspond to the seven days of the week."""
-        commits = [_make_commit(datetime.date(2024, 1, d)) for d in (1, 8, 15)]
-        parsed = json.loads(_build_heatmap_daily(commits, datetime.date(2024, 1, 31)))
-        assert len(parsed["data"][0]["z"]) == 7
-
-    def test_rolling_window_excludes_commits_before_cutoff(self) -> None:
-        """Commits older than max_days before window_end produce null."""
-        old_commit = _make_commit(datetime.date(2023, 1, 1))
-        window_end = datetime.date(2024, 3, 31)
-        # max_days=90 places rolling_start at 2024-01-02; old commit is excluded.
-        result = _build_heatmap_daily([old_commit], window_end, max_days=90)
-        assert result == "null"
-
-    def test_recent_commit_within_rolling_window_is_included(self) -> None:
-        """A commit within max_days of window_end produces a valid chart."""
-        recent = _make_commit(datetime.date(2024, 3, 1))
-        window_end = datetime.date(2024, 3, 31)
-        assert _is_valid_chart_json(_build_heatmap_daily([recent], window_end, max_days=90))
-
-    def test_column_count_matches_weeks_in_rolling_window(self) -> None:
-        """Column count equals the number of calendar weeks in the window.
-
-        window_end = 2024-01-28 (Sunday), max_days = 28.
-        rolling_start = 2024-01-01 (Monday).
-        Weeks: Jan 01, Jan 08, Jan 15, Jan 22 -> 4 columns.
-        """
-        commits = [_make_commit(datetime.date(2024, 1, 15))]
-        parsed = json.loads(_build_heatmap_daily(commits, datetime.date(2024, 1, 28), max_days=28))
-        assert len(parsed["data"][0]["x"]) == 4
-
-    def test_xaxis_type_is_category(self) -> None:
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        result = json.loads(_build_heatmap_daily(commits, datetime.date(2024, 1, 31)))
-        assert result["layout"]["xaxis"]["type"] == "category"
-
-    def test_customdata_shape_matches_z_shape(self) -> None:
-        """customdata must have the same dimensions as z for hover to work."""
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        parsed = json.loads(_build_heatmap_daily(commits, datetime.date(2024, 1, 31)))
-        z = parsed["data"][0]["z"]
-        cd = parsed["data"][0]["customdata"]
-        assert len(cd) == len(z)
-        assert all(len(cd[i]) == len(z[i]) for i in range(len(z)))
-
-    def test_dispatch_daily_via_build_heatmap_chart(self) -> None:
-        commits = [_make_commit(datetime.date(2024, 1, 8))]
-        result = _build_heatmap_chart(commits, "daily", window_end=datetime.date(2024, 1, 31))
-        assert _is_valid_chart_json(result)
-
-    def test_dispatch_daily_without_window_end_defaults_to_max_commit_date(
+    def test_empty_commits_returns_valid_json_with_empty_aggregated_counts(
         self,
     ) -> None:
+        result = _build_heatmap_data([], [], datetime.date(2024, 1, 1), datetime.date(2024, 12, 31))
+        parsed = json.loads(result)
+        assert parsed["daily_counts"]["__aggregated__"] == {}
+
+    def test_years_span_full_analysis_window(self) -> None:
+        result = _build_heatmap_data([], [], datetime.date(2022, 6, 1), datetime.date(2024, 3, 31))
+        assert json.loads(result)["years"] == [2022, 2023, 2024]
+
+    def test_single_year_window_produces_one_year(self) -> None:
+        result = _build_heatmap_data([], [], datetime.date(2024, 1, 1), datetime.date(2024, 12, 31))
+        assert json.loads(result)["years"] == [2024]
+
+    def test_aggregated_contributor_is_always_first(self) -> None:
+        result = _build_heatmap_data([], [], datetime.date(2024, 1, 1), datetime.date(2024, 12, 31))
+        assert json.loads(result)["contributors"][0]["email"] == "__aggregated__"
+
+    def test_aggregated_counts_sum_all_contributors(self) -> None:
         commits = [
-            _make_commit(datetime.date(2024, 1, 8)),
-            _make_commit(datetime.date(2024, 1, 20)),
+            _make_commit(datetime.date(2024, 3, 15), email="a@example.com"),
+            _make_commit(datetime.date(2024, 3, 15), email="b@example.com"),
+            _make_commit(datetime.date(2024, 3, 20), email="a@example.com"),
         ]
-        result = _build_heatmap_chart(commits, "daily")
-        assert _is_valid_chart_json(result)
+        result = _build_heatmap_data(
+            commits, [], datetime.date(2024, 1, 1), datetime.date(2024, 12, 31)
+        )
+        agg = json.loads(result)["daily_counts"]["__aggregated__"]
+        assert agg["2024-03-15"] == 2
+        assert agg["2024-03-20"] == 1
+
+    def test_per_contributor_counts_keyed_by_lowercased_email(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 3, 15), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 15), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 20), email="bob@example.com"),
+        ]
+        ranked = [
+            _make_ranked("Alice", commit_count=2),
+            _make_ranked("Bob", commit_count=1),
+        ]
+        result = _build_heatmap_data(
+            commits, ranked, datetime.date(2024, 1, 1), datetime.date(2024, 12, 31)
+        )
+        counts = json.loads(result)["daily_counts"]
+        assert counts["alice@example.com"]["2024-03-15"] == 2
+        assert counts["bob@example.com"]["2024-03-20"] == 1
+
+    def test_contributor_list_follows_ranked_order(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 3, 15), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 20), email="bob@example.com"),
+        ]
+        ranked = [
+            _make_ranked("Alice", commit_count=5),
+            _make_ranked("Bob", commit_count=2),
+        ]
+        result = _build_heatmap_data(
+            commits, ranked, datetime.date(2024, 1, 1), datetime.date(2024, 12, 31)
+        )
+        contributors = json.loads(result)["contributors"]
+        assert contributors[0]["email"] == "__aggregated__"
+        assert contributors[1]["email"] == "alice@example.com"
+        assert contributors[2]["email"] == "bob@example.com"
+
+    def test_payload_contains_required_top_level_keys(self) -> None:
+        result = _build_heatmap_data([], [], datetime.date(2024, 1, 1), datetime.date(2024, 12, 31))
+        parsed = json.loads(result)
+        assert "years" in parsed
+        assert "contributors" in parsed
+        assert "daily_counts" in parsed
+
+    def test_script_closing_tag_is_escaped(self) -> None:
+        """</script> in any embedded string must not appear raw in the output."""
+        commits = [_make_commit(datetime.date(2024, 3, 15))]
+        result = _build_heatmap_data(
+            commits, [], datetime.date(2024, 1, 1), datetime.date(2024, 12, 31)
+        )
+        assert "</script>" not in result
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/services/test_report.py
+++ b/tests/unit/services/test_report.py
@@ -216,7 +216,6 @@ class TestGenerateReport:
             def capture_render(
                 data: ReportData,
                 path: Path,
-                heatmap_granularity: str = "monthly",
             ) -> Path:
                 captured.append(data)
                 return path

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -54,7 +54,6 @@ class TestWriteInitConfig:
             "branch",
             "since",
             "until",
-            "heatmap_granularity",
             "min_commits",
             "exclude_authors",
             "enabled",


### PR DESCRIPTION
## Problem
The four-granularity heatmap toggle (daily/weekly/monthly/yearly) embedded
four full Plotly specs per report, inflating payload ~4x for a feature that
provided limited value. There was no per-contributor view, no year navigation,
and no coherent mental model for what toggling chart structure accomplished.

## Changes
- Replaced four embedded Plotly specs with a single compact daily-count JSON
  payload (O(commits) rather than O(commits × 4 granularities × full layout))
- GitHub-style 7-row grid (Mon–Sun rows, calendar-week columns) with UTC-based
  arithmetic handling leap years correctly
- Year tabs derived from the analysis window; most recent year active by default
- Contributor dropdown: aggregated view default, per-contributor on selection
- Single-contributor reports hide the dropdown automatically
- `--heatmap-granularity` flag and `heatmap_granularity` TOML key removed;
  existing config files with the key are silently unaffected

## Verification
160 tests passing. Visually verified against the live reveille repository:
year tabs, contributor switching, dark mode, leap year grid, hover tooltips.