### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
+## [0.4.0] — 2026-05-12
+
+### Added
+
+- Activity heatmap redesigned as a GitHub-style year-navigable grid.
+  Rows represent days of the week (Monday–Sunday); columns represent
+  calendar weeks. Year tabs derived from the analysis window allow
+  switching between calendar years without regenerating the report.
+  A contributor dropdown provides per-contributor views alongside the
+  default aggregated view. Leap years are handled correctly through
+  UTC-based date arithmetic. The four-spec embed (daily/weekly/monthly/
+  yearly) is replaced by a single compact daily-count JSON payload,
+  reducing embedded heatmap data size proportional to the number of
+  years in the analysis window.
+
+### Removed
+
+- `--heatmap-granularity` CLI flag removed. The concept of switching
+  between weekly/monthly/yearly chart structures is superseded by year
+  navigation within a single canonical grid layout.
+- `heatmap_granularity` TOML key removed from `ReportConfig` and the
+  `[report]` section of `reveille.toml`. Existing configuration files
+  containing this key are unaffected — the key is silently ignored by
+  the TOML parser.
+- `HeatmapGranularity` type alias removed from `reveille.domain.models`.
+
+---
+
 ## [0.3.3] — 2026-05-12
 
 ### Added
@@ -23,16 +51,6 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   display the relevant help text. Implemented via Click's `help_option_names`
   context setting, which propagates the alias to every subcommand without
   per-command wiring.
-- Activity heatmap redesigned as a GitHub-style year-navigable grid.
-  Rows represent days of the week (Monday–Sunday); columns represent
-  calendar weeks. Year tabs derived from the analysis window allow
-  switching between calendar years without regenerating the report.
-  A contributor dropdown provides per-contributor views alongside the
-  default aggregated view. Leap years are handled correctly through
-  UTC-based date arithmetic. The four-spec embed (daily/weekly/monthly/
-  yearly) is replaced by a single compact daily-count JSON payload,
-  reducing embedded heatmap data size proportional to the number of
-  years in the analysis window.
 
 ### Fixed
 
@@ -42,16 +60,6 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   Reveille attempted to render help output — including on bare `reveille`
   invocations due to `no_args_is_help=True`. Typer 0.18.0 restores full
   Click 8.3.x compatibility.
-
-### Removed
-- `--heatmap-granularity` CLI flag removed. The concept of switching
-  between weekly/monthly/yearly chart structures is superseded by year
-  navigation within a single canonical grid layout.
-- `heatmap_granularity` TOML key removed from `ReportConfig` and the
-  `[report]` section of `reveille.toml`. Existing configuration files
-  containing this key are unaffected — the key is silently ignored by
-  the TOML parser.
-- `HeatmapGranularity` type alias removed from `reveille.domain.models`.
 
 ---
 
@@ -245,7 +253,8 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.4.0
 [0.3.3]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.3.3
 [0.3.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.3.0
 [0.2.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to Reveille
+
+Thank you for considering a contribution. Please read this document
+before opening a pull request.
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/varaprasadchilakanti/reveille/issues).
+Include the output of `reveille --version`, your operating system,
+your Python version, and a minimal reproduction case. If the issue
+involves a specific repository, a sanitised `git log --oneline`
+covering the relevant range is sufficient — do not include source code.
+
+## Proposing Changes
+
+Open an issue before beginning significant work. This prevents
+duplicated effort and ensures alignment with the project's direction
+before time is invested. Contributions that arrive without prior
+discussion may be declined regardless of their quality.
+
+## Development Environment
+
+Requires Python 3.11 or later and `git`.
+
+```bash
+git clone git@github.com:varaprasadchilakanti/reveille.git
+cd reveille
+poetry install
+poetry run pre-commit install
+```
+
+Verify the environment:
+
+```bash
+poetry run reveille --version
+poetry run mypy src/
+poetry run ruff check src/
+poetry run pytest -n auto
+```
+
+## Architecture
+
+Reveille follows Clean Architecture strictly. The dependency rule is
+absolute: outer layers depend on inner layers, never the reverse.
+
+- `src/reveille/domain/` — pure Python dataclasses and the ranking
+  engine. No framework imports, no I/O.
+- `src/reveille/adapters/` — `GitReader` (the only layer that imports
+  GitPython) and `Renderer` (the only layer that imports Jinja2 and
+  Plotly).
+- `src/reveille/services/` — the `generate_report` orchestrator.
+  No knowledge of infrastructure libraries.
+- `src/reveille/cli.py` — argument parsing and progress display only.
+  No business logic.
+
+New behaviour belongs in the layer that owns its concern. Domain logic
+that acquires a framework import is a layering violation.
+
+## Submitting Pull Requests
+
+All pull requests must target the `main` branch. The CI pipeline runs
+`ruff`, `mypy`, and `pytest` across Python 3.11 and 3.12. All three
+must pass. A pull request will not be merged if any check fails.
+
+The output contract is non-negotiable and must be preserved in every
+contribution: the generated file is always a single self-contained
+`.html` file with no external dependencies, no CDN calls, no cookies,
+and no tracking.
+
+New public functions require Google-style docstrings. New behaviour
+requires tests. The existing three-layer test pyramid (unit,
+integration, end-to-end) is the structure to follow — add tests in
+the layer appropriate to what is being exercised.
+
+## Code Style
+
+Ruff handles linting and import ordering. Mypy runs in strict mode.
+Type annotations are required on every function signature. Early
+returns are preferred over nested conditionals.
+
+Run the full quality suite before pushing:
+
+```bash
+poetry run ruff check src tests
+poetry run ruff format src tests
+poetry run mypy src
+poetry run pytest -n auto
+```
+
+## Commit Messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/)
+specification. Scope is optional but encouraged.
+
+```
+feat(ranking): add recency decay weighting
+fix(cli): use None sentinel for min_commits to preserve CLI precedence
+docs(readme): add uv installation instructions
+refactor(renderer): extract pie data aggregation into helper
+test(e2e): verify help command exits zero and lists known subcommands
+chore(release): bump version to 0.4.0
+```
+
+## Licence
+
+By contributing to Reveille, you agree that your contributions will
+be licensed under the [MIT Licence](LICENSE).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Reveille is designed for developers, engineering managers, and technical leads w
 
 **What it produces:**
 
-- Contribution heatmaps showing commit activity across four granularity levels: per calendar day, per calendar week, per calendar month, and per calendar year — switchable in the rendered report without regeneration
+- Contribution heatmap with a GitHub-style year-navigable grid showing per-day commit activity. Year tabs allow switching between calendar years; a contributor dropdown surfaces per-contributor views alongside the aggregated default.
 - Commit frequency timelines and rolling activity charts
 - Per-contributor breakdowns covering commits, lines added and removed, and active day counts
 - A structured ranking table assigning each contributor a tier designation based on weighted activity metrics
@@ -49,35 +49,49 @@ Reveille is designed for developers, engineering managers, and technical leads w
 
 Reveille requires Python 3.11 or later.
 
-**Install from PyPI:**
+<details open>
+<summary><strong>pip</strong></summary>
 
 ```bash
 pip install reveille
 ```
 
-**Install with pipx (recommended for CLI tools):**
+</details>
+
+<details>
+<summary><strong>pipx (recommended for CLI tools)</strong></summary>
 
 ```bash
 pipx install reveille
 ```
 
-**Install with Poetry (within a Poetry-managed project):**
+</details>
 
-```bash
-poetry add reveille
-```
+<details>
+<summary><strong>uv</strong></summary>
 
-**Install with uv:**
+Install permanently as a tool:
 
 ```bash
 uv tool install reveille
 ```
 
-**Run without a permanent install (uv):**
+Run without a permanent install:
 
 ```bash
 uvx reveille generate --repo /path/to/repository
 ```
+
+</details>
+
+<details>
+<summary><strong>Poetry (within a Poetry-managed project)</strong></summary>
+
+```bash
+poetry add reveille
+```
+
+</details>
 
 **Verify the installation:**
 
@@ -143,7 +157,6 @@ Generates the HTML performance report for the target repository.
 | `--min-commits` | | `INT` | `1` | Exclude contributors with fewer than this many commits in the analysis window. |
 | `--title` | | `TEXT` | Repository name | Override the report title displayed in the HTML output. |
 | `--no-ranking` | | Flag | Off | Omit the contributor ranking table from the output. |
-| `--heatmap-granularity` | | `TEXT` | `monthly` | Default heatmap view on open. Accepted values: `daily`, `weekly`, `monthly`, `yearly`. All four views are available via toggle buttons in the rendered report regardless of this setting. |
 | `--config` | `-c` | `PATH` | None | Path to a TOML configuration file. If omitted, `reveille.toml` in the current working directory is loaded automatically when present. Use this flag for non-standard file names or paths outside the repository root. CLI flags always take precedence over configuration file values. |
 
 ### `reveille init`
@@ -183,7 +196,7 @@ The generated HTML file is structured as a formal report with the following sect
 
 **Repository Summary** — Name, remote URL if present, default branch, total commits in the analysis window, unique contributors, date range, and report generation timestamp.
 
-**Activity Heatmap** — A calendar-style matrix showing commit frequency across the analysis window. Four granularity views are available via toggle buttons in the rendered report: `daily` shows one cell per calendar day in a GitHub-style grid capped at a rolling 365-day window; `weekly` and `monthly` aggregate by day-of-week across each week or month; `yearly` aggregates by month across each calendar year. The `--heatmap-granularity` flag controls which view is active on first open.
+**Activity Heatmap** — A GitHub-style year-navigable grid showing commit frequency by calendar day. Rows represent days of the week (Monday–Sunday); columns represent calendar weeks. Year tabs derived from the analysis window allow switching between calendar years without regenerating the report. A contributor dropdown provides per-contributor views alongside the aggregated default; single-contributor repositories hide the dropdown automatically.
 
 **Commit Timeline** — A rolling area chart showing commit volume per calendar week over the analysis window. Highlights periods of high and low activity.
 
@@ -243,8 +256,6 @@ output = "./reports/q4-2024.html"
 branch = "main"
 since = "2024-10-01"
 until = "2024-12-31"
-# Accepted values: "daily", "weekly", "monthly", "yearly"
-heatmap_granularity = "monthly"
 
 [filters]
 min_commits = 2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Only the current stable release receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 0.4.x   | ✓         |
+| < 0.4.0 | ✗         |
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for security vulnerabilities.
+
+Use GitHub's private vulnerability reporting:
+[Report a vulnerability](https://github.com/varaprasadchilakanti/reveille/security/advisories/new)
+
+Include a description of the vulnerability and its potential impact,
+steps to reproduce it, and the version of Reveille and Python in use.
+
+You can expect an acknowledgement within 48 hours. Confirmed
+vulnerabilities will receive a resolution timeline within 7 days.
+
+## Scope
+
+Reveille is a local analysis tool. It reads only the Git repository
+it is explicitly pointed at, produces a single HTML output file, and
+does not transmit data over a network. It does not accept inbound
+connections and does not execute content from commit messages or file
+contents. The primary attack surface is maliciously crafted Git
+repository content that could affect the HTML output, or
+vulnerabilities in the runtime dependency chain (GitPython, Jinja2,
+Plotly, Typer).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -153,41 +153,6 @@ ranking context would be distracting or misinterpreted.
 reveille generate --no-ranking
 ```
 
-### `--heatmap-granularity`
-
-Controls the time resolution of the commit activity heatmap and sets the
-default view when the report is first opened. Four values are accepted.
-
-`daily` produces a GitHub-style grid with one cell per calendar day. Rows
-represent days of the week and columns represent calendar weeks. The view
-is capped at a rolling 365-day window ending at the analysis window's end
-date, preventing excessive chart width for repositories with multi-year
-histories. This view is best for active repositories where per-day
-granularity is meaningful.
-
-`weekly` produces one column per calendar week with rows for each day of
-the week. This is the most granular aggregated view and is best suited to
-repositories with fewer than six months of history in the analysis window.
-At longer ranges, the chart becomes too wide to read comfortably.
-
-`monthly` is the default. It produces one column per calendar month with
-rows for each day of the week. Each cell contains the total commit count
-for that weekday across all occurrences within the month. This view
-balances detail and readability for most repository histories.
-
-`yearly` produces one column per calendar year with rows for each month.
-This view is appropriate for repositories with more than three years of
-history, where weekly or monthly resolution would produce an unreadably
-wide chart.
-
-```bash
-reveille generate --heatmap-granularity daily
-```
-
-The generated HTML report embeds all four granularity specifications and
-provides toggle buttons to switch between them without regenerating the
-file. The `--heatmap-granularity` flag controls only which view is active
-on first open.
 
 ### `--config` / `-c`
 
@@ -269,12 +234,6 @@ since = "2024-10-01"
 # Analysis window end date. Equivalent to --until.
 until = "2024-12-31"
 
-# Heatmap resolution. Equivalent to --heatmap-granularity.
-# Accepted values: "daily", "weekly", "monthly", "yearly"
-# Controls the default view on open; all four are accessible via toggle
-# buttons in the rendered report without regenerating the file.
-heatmap_granularity = "monthly"
-
 
 [filters]
 # Minimum commits to include a contributor. Equivalent to --min-commits.
@@ -318,23 +277,18 @@ recorded.
 
 ### Activity Heatmap
 
-The heatmap visualises when commits occurred across the analysis window.
-Darker cells indicate higher commit volumes. Empty cells — rendered as
-transparent — indicate periods of no activity. Persistent gaps may
-indicate holidays, sprints with no deliverables, or periods of reduced
-team capacity.
+The heatmap visualises when commits occurred across the analysis window as
+a GitHub-style calendar grid. Rows represent days of the week
+(Monday–Sunday); columns represent calendar weeks. Darker cells indicate
+higher commit volumes. Empty cells — rendered as transparent — indicate
+periods of no activity. Persistent gaps may indicate holidays, sprints
+with no deliverables, or periods of reduced team capacity.
 
-Four granularity views are available and can be switched using the toggle
-buttons above the chart without regenerating the report. The `daily` view
-shows one cell per calendar day in a GitHub-style grid capped at a rolling
-365-day window; rows are days of the week and columns are calendar weeks.
-The `weekly` and `monthly` views aggregate commit counts by weekday within
-each week or month respectively, with rows for days of the week and columns
-for the time period. The `yearly` view aggregates by month, with rows for
-each month of the year and columns for each calendar year; it is best
-suited to repositories with more than three years of history. The
-`--heatmap-granularity` flag controls which view is active when the file
-is first opened.
+Year tabs above the chart allow switching between calendar years covered
+by the analysis window without regenerating the report. The most recent
+year is active by default. A contributor dropdown provides per-contributor
+views alongside the aggregated default. In single-contributor repositories,
+the dropdown is hidden automatically.
 
 ### Weekly Commit Timeline
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.3.3"
+version = "0.4.0"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Varaprasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "MIT"
@@ -256,7 +256,7 @@ omit = [
 precision = 2
 show_missing = true
 
-fail_under = 80
+fail_under = 90
 
 exclude_lines = [
     "pragma: no cover",

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -4,7 +4,7 @@ A CLI tool that generates self-contained HTML performance reports
 from local Git repositories.
 """
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 __author__ = "Varaprasad Chilakanti"
 __email__ = "varaprasadchilakanti@gmail.com"
 __licence__ = "MIT"


### PR DESCRIPTION
### Added

- Activity heatmap redesigned as a GitHub-style year-navigable grid.
  Rows represent days of the week (Monday–Sunday); columns represent
  calendar weeks. Year tabs derived from the analysis window allow
  switching between calendar years without regenerating the report.
  A contributor dropdown provides per-contributor views alongside the
  default aggregated view. Leap years are handled correctly through
  UTC-based date arithmetic. The four-spec embed (daily/weekly/monthly/
  yearly) is replaced by a single compact daily-count JSON payload,
  reducing embedded heatmap data size proportional to the number of
  years in the analysis window.

### Removed

- `--heatmap-granularity` CLI flag removed. The concept of switching
  between weekly/monthly/yearly chart structures is superseded by year
  navigation within a single canonical grid layout.
- `heatmap_granularity` TOML key removed from `ReportConfig` and the
  `[report]` section of `reveille.toml`. Existing configuration files
  containing this key are unaffected — the key is silently ignored by
  the TOML parser.
- `HeatmapGranularity` type alias removed from `reveille.domain.models`.
