### PR TITLE
chore(tech-debt): delegate validate to GitReader and add ReportConfigKwargs TypedDict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,8 @@ reveille-report.html
 *.reveille.html
 reports/
 
+# Manual staging area for untracked files
+notrack/
 
 # ------------------------------------------------------------------
 # TEMPORARY & BACKUP FILES

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -17,12 +17,12 @@ import sys
 import threading
 from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated, ClassVar
+from typing import Annotated, Any, ClassVar, cast
 
 import typer
 
 from reveille import __version__
-from reveille.config import ReportConfig
+from reveille.config import ReportConfig, ReportConfigKwargs
 from reveille.exceptions import ConfigurationError, RevelleError
 
 app = typer.Typer(
@@ -171,7 +171,7 @@ def _resolve_output_path(output: Path, repo_path: Path) -> Path:
 
 
 def _merge_cli_flags(
-    config_kwargs: dict[str, object],
+    config_kwargs: ReportConfigKwargs,
     repo: Path,
     output: Path,
     since: str | None,
@@ -181,7 +181,7 @@ def _merge_cli_flags(
     exclude_author: list[str] | None,
     min_commits: int | None,
     no_ranking: bool,
-) -> dict[str, object]:
+) -> ReportConfigKwargs:
     """Merge CLI flag values into the base configuration dict.
 
     CLI flag values always take precedence over configuration file values.
@@ -189,7 +189,7 @@ def _merge_cli_flags(
     default) are only applied when no configuration file provided a value.
 
     Args:
-        config_kwargs: Base kwargs loaded from a TOML file, or empty dict.
+        config_kwargs: Base kwargs loaded from a TOML file, or empty mapping.
         repo: Resolved repository path from --repo flag.
         output: Output path from --output flag.
         since: Raw since date string, or None if not provided.
@@ -197,21 +197,18 @@ def _merge_cli_flags(
         branch: Branch name, or None if not provided.
         title: Report title override, or None if not provided.
         exclude_author: List of authors to exclude, or None.
-        min_commits: Minimum commit threshold.
+        min_commits: Minimum commit threshold, or None if not provided.
         no_ranking: Whether ranking is disabled.
-        heatmap_granularity: Heatmap resolution string, or None if not provided.
 
     Returns:
-        A merged dict ready for ReportConfig construction.
+        A merged ReportConfigKwargs ready for ReportConfig construction.
     """
-    merged = dict(config_kwargs)
-    merged["repo_path"] = repo.resolve()
+    merged: dict[str, Any] = dict(config_kwargs)
+    resolved_repo = repo.resolve()
+    merged["repo_path"] = resolved_repo
 
     if output != Path("reveille-report.html") or "output_path" not in merged:
-        merged["output_path"] = _resolve_output_path(
-            output,
-            merged["repo_path"],  # type: ignore[arg-type]
-        )
+        merged["output_path"] = _resolve_output_path(output, resolved_repo)
     if since is not None:
         merged["since"] = _parse_date(since, "--since")
     if until is not None:
@@ -227,7 +224,7 @@ def _merge_cli_flags(
     if no_ranking:
         merged["ranking_enabled"] = False
 
-    return merged
+    return cast(ReportConfigKwargs, merged)
 
 
 @app.command()
@@ -280,7 +277,7 @@ def generate(
     from reveille.config import load_config_from_toml
     from reveille.services.report import generate_report
 
-    config_kwargs: dict[str, object] = {}
+    config_kwargs: ReportConfigKwargs = cast(ReportConfigKwargs, {})
     _auto_discovered = config is None
     _config_path = config if config is not None else _discover_config()
     if _config_path is not None:
@@ -313,7 +310,7 @@ def generate(
     )
 
     try:
-        report_config = ReportConfig(**merged)  # type: ignore[arg-type]
+        report_config = ReportConfig(**merged)
     except ValueError as exc:
         typer.echo(f"Configuration error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
@@ -341,10 +338,14 @@ def validate(
     ] = Path("."),
 ) -> None:
     """Validate that the target path is a readable Git repository."""
+    from reveille.adapters.git_reader import GitReader
+
     resolved = repo.resolve()
-    if not (resolved / ".git").exists():
-        typer.echo(f"Error: {resolved} does not contain a .git directory.", err=True)
-        raise typer.Exit(code=1)
+    try:
+        GitReader(resolved)
+    except RevelleError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     typer.echo(f"Repository at {resolved} is valid.")
 
 

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import datetime
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -86,19 +86,44 @@ class ReportConfig(BaseModel):
         return self
 
 
-def load_config_from_toml(path: Path) -> dict[str, Any]:
+class ReportConfigKwargs(TypedDict, total=False):
+    """Typed keyword-argument mapping for ReportConfig construction.
+
+    All keys carry total=False because the dict is assembled incrementally:
+    first from an optional TOML file, then from CLI flag overrides. Absent
+    keys fall back to the ReportConfig field default at construction time.
+
+    since and until are typed as datetime.date (not datetime.date | None)
+    because when present in the mapping, the value is always a concrete
+    date. The Optional annotation on ReportConfig expresses the
+    absence-of-key default, not a stored None.
+    """
+
+    repo_path: Path
+    output_path: Path
+    title: str | None
+    branch: str | None
+    since: datetime.date
+    until: datetime.date
+    exclude_authors: list[str]
+    min_commits: int
+    ranking_enabled: bool
+    ranking_weights: RankingWeights
+
+
+def load_config_from_toml(path: Path) -> ReportConfigKwargs:
     """Load and flatten configuration values from a Reveille TOML file.
 
     Reads the structured TOML format documented in the README and returns
-    a flat dict of keyword arguments suitable for constructing a ReportConfig.
-    Only keys present in the file are included in the returned dict -- absent
-    keys do not override CLI defaults.
+    a typed keyword-argument mapping suitable for constructing a ReportConfig.
+    Only keys present in the file are included — absent keys do not override
+    CLI defaults.
 
     Args:
         path: Path to the TOML configuration file.
 
     Returns:
-        A dict of ReportConfig-compatible keyword arguments.
+        A ReportConfigKwargs mapping of ReportConfig-compatible keyword arguments.
 
     Raises:
         ConfigurationError: If the file does not exist, cannot be read,
@@ -112,11 +137,11 @@ def load_config_from_toml(path: Path) -> dict[str, Any]:
     except tomllib.TOMLDecodeError as exc:
         raise ConfigurationError(f"Configuration file is not valid TOML: {exc}") from exc
 
-    kwargs: dict[str, Any] = {}
-    kwargs.update(_parse_report_section(raw.get("report", {})))
-    kwargs.update(_parse_filters_section(raw.get("filters", {})))
-    kwargs.update(_parse_ranking_section(raw.get("ranking", {})))
-    return kwargs
+    parts: dict[str, Any] = {}
+    parts.update(_parse_report_section(raw.get("report", {})))
+    parts.update(_parse_filters_section(raw.get("filters", {})))
+    parts.update(_parse_ranking_section(raw.get("ranking", {})))
+    return cast(ReportConfigKwargs, parts)
 
 
 def _parse_report_section(report: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Problem

Two known technical debt items deferred since initial development:

1. `validate` performed a raw `.git` directory existence check rather than
   delegating to `GitReader`. Every other command that reads a repository
   goes through `GitReader`, whose `__init__` validates the path and raises
   `RepositoryError` with a diagnostic message. `validate` was the only
   exception, producing a different error message format and bypassing the
   adapter entirely.

2. `_merge_cli_flags` returned `dict[str, object]`, which is too wide for
   Pydantic's typed constructor. `ReportConfig(**merged)` carried a
   `type: ignore[arg-type]` suppression since v0.1.0 with a note to resolve
   via TypedDict.

## Fix

**`validate` delegation:** The command now constructs `GitReader(resolved)`.
`RepositoryError` (and any other `RevelleError`) is caught at the CLI
boundary and emitted as `Error: <adapter diagnostic>` to stderr with exit
code 1. Error message format is now consistent with `generate` and `init`.
No behaviour change for valid repositories.

**`ReportConfigKwargs` TypedDict:** Added to `config.py` with `total=False`
(all keys optional — the mapping is assembled incrementally from TOML then
CLI overrides). `load_config_from_toml` return type updated from
`dict[str, Any]` to `ReportConfigKwargs`. `_merge_cli_flags` accepts and
returns `ReportConfigKwargs`. `ReportConfig(**merged)` in `generate` resolves
cleanly under strict mypy without suppression.

Internal assembly in both functions uses `dict[str, Any]` with a single
`cast(ReportConfigKwargs, ...)` at each return boundary — the correct
trade-off where the construction is dynamically typed but the public
interface is explicitly typed.

## Verification

- 160 tests pass (`pytest -n auto`)
- `mypy src/` passes with zero errors
- `ruff check src/` passes clean
- Existing `validate` e2e tests pass without modification