### PR TITLE
feat(renderer): add per-contributor weekly commit frequency chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Per-contributor weekly commit frequency chart added as a new report
+  section between the aggregate commit timeline and the contributor
+  rankings table. Each contributor is represented as a separate trace,
+  enabling direct comparison of burst contributors versus sustained
+  low-volume engagement across the analysis window.
+
 ---
 
 ## [0.4.1] — 2026-05-12

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -196,6 +196,9 @@ class Renderer:
         """
         return {
             "timeline": _build_timeline_chart(data.commits),
+            "contributor_timeline": _build_contributor_timeline_chart(
+                data.commits, data.ranked_contributors
+            ),
             "heatmap": _build_heatmap_data(
                 data.commits,
                 data.ranked_contributors,
@@ -259,6 +262,77 @@ def _build_timeline_chart(commits: list[Commit]) -> str:
         xaxis_title="Week",
         yaxis_title="Commits",
         height=280,
+    )
+    return _to_json(fig)
+
+
+def _build_contributor_timeline_chart(
+    commits: list[Commit],
+    ranked: list[RankedContributor],
+) -> str:
+    """Build a per-contributor weekly commit frequency line chart.
+
+    Each contributor in the ranked list is represented as a separate
+    Scatter trace. Commits from contributors absent from the ranked list
+    (filtered by min_commits) are excluded. Traces follow the ranked
+    order so the highest-composite-score contributor appears first in
+    the legend.
+
+    Args:
+        commits: All commits in the analysis window.
+        ranked: Ranked contributor list in composite score order.
+
+    Returns:
+        A Plotly figure JSON string, or 'null' if fewer than two
+        contributors are present or no commits fall within the window.
+    """
+    if not commits or len(ranked) < 2:
+        return "null"
+
+    weekly_per_email: dict[str, dict[str, int]] = {r.stats.email.lower(): {} for r in ranked}
+
+    for commit in commits:
+        email = commit.author_email.lower()
+        if email not in weekly_per_email:
+            continue
+        d = commit.timestamp.date()
+        week_start = (d - datetime.timedelta(days=d.weekday())).isoformat()
+        weekly_per_email[email][week_start] = weekly_per_email[email].get(week_start, 0) + 1
+
+    all_weeks = sorted({week for bins in weekly_per_email.values() for week in bins})
+    if not all_weeks:
+        return "null"
+
+    fig = go.Figure()
+    for i, r in enumerate(ranked):
+        email = r.stats.email.lower()
+        bins = weekly_per_email.get(email, {})
+        counts = [bins.get(w, 0) for w in all_weeks]
+        fig.add_trace(
+            go.Scatter(
+                x=all_weeks,
+                y=counts,
+                mode="lines",
+                name=r.stats.name,
+                line={"color": _PIE_PALETTE[i % len(_PIE_PALETTE)], "width": 2},
+                hovertemplate="Week of %{x}<br>Commits: %{y}<extra></extra>",
+            )
+        )
+
+    layout = _base_layout()
+    layout["xaxis"] = {
+        "type": "category",
+        "gridcolor": "#e2e8f0",
+        "linecolor": "#d1d9e0",
+        "tickangle": -45,
+    }
+    layout["showlegend"] = True
+    layout["legend"] = {"orientation": "h", "y": 1.12, "x": 0}
+    fig.update_layout(
+        **layout,
+        xaxis_title="Week",
+        yaxis_title="Commits",
+        height=320,
     )
     return _to_json(fig)
 

--- a/src/reveille/templates/report.html.j2
+++ b/src/reveille/templates/report.html.j2
@@ -571,6 +571,16 @@
     </div>
 
     <!-- ============================================================
+         Per-Contributor Commit Frequency
+         ============================================================ -->
+    <div class="section">
+        <h2 class="section-title">Per-Contributor Commit Frequency</h2>
+        <div class="chart-container">
+            <div id="chart-contributor_timeline"></div>
+        </div>
+    </div>
+
+    <!-- ============================================================
          Contributor Rankings
          ============================================================ -->
     {% if data.ranked_contributors %}
@@ -719,6 +729,9 @@
 <script type="application/json" id="spec-timeline">
 {{ charts.timeline | safe }}
 </script>
+<script type="application/json" id="spec-contributor_timeline">
+{{ charts.contributor_timeline | safe }}
+</script>
 <script type="application/json" id="spec-heatmap">
 {{ charts.heatmap | safe }}
 </script>
@@ -746,6 +759,7 @@
 
     var CHART_IDS = [
         'timeline',
+        'contributor_timeline',
         'contributor_commits',
         'contributor_lines',
         'pie_commits',

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -490,6 +490,12 @@ class TestGenerateCommand:
         """The compact heatmap data payload is embedded in the output."""
         assert 'id="spec-heatmap"' in default_report_content
 
+    def test_output_contains_contributor_timeline_spec_block(
+        self, default_report_content: str
+    ) -> None:
+        """The per-contributor timeline spec block is embedded in the output."""
+        assert 'id="spec-contributor_timeline"' in default_report_content
+
     def test_auto_discovers_reveille_toml_in_cwd(
         self,
         e2e_repo: Path,

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -21,6 +21,7 @@ from reveille.adapters.renderer import (
     _build_commit_share_pie,
     _build_contributor_commits_chart,
     _build_contributor_lines_chart,
+    _build_contributor_timeline_chart,
     _build_heatmap_data,
     _build_lines_share_pie,
     _build_timeline_chart,
@@ -230,6 +231,103 @@ class TestBuildTimelineChart:
         ]
         result = json.loads(_build_timeline_chart(commits))
         assert result["layout"]["xaxis"]["type"] == "category"
+
+
+@pytest.mark.unit
+class TestBuildContributorTimelineChart:
+    """Tests for the per-contributor weekly commit frequency chart builder."""
+
+    def test_empty_commits_returns_null_sentinel(self) -> None:
+        ranked = [
+            _make_ranked("Alice", commit_count=10),
+            _make_ranked("Bob", commit_count=5),
+        ]
+        assert _build_contributor_timeline_chart([], ranked) == "null"
+
+    def test_single_contributor_returns_null_sentinel(self) -> None:
+        commits = [_make_commit(datetime.date(2024, 3, 11), email="alice@example.com")]
+        ranked = [_make_ranked("Alice", commit_count=1)]
+        assert _build_contributor_timeline_chart(commits, ranked) == "null"
+
+    def test_two_contributors_return_valid_chart_json(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 3, 11), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 18), email="bob@example.com"),
+        ]
+        ranked = [
+            _make_ranked("Alice", commit_count=1),
+            _make_ranked("Bob", commit_count=1),
+        ]
+        assert _is_valid_chart_json(_build_contributor_timeline_chart(commits, ranked))
+
+    def test_returns_one_trace_per_contributor(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 3, 11), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 18), email="bob@example.com"),
+            _make_commit(datetime.date(2024, 3, 25), email="carol@example.com"),
+        ]
+        ranked = [
+            _make_ranked("Alice", commit_count=1),
+            _make_ranked("Bob", commit_count=1),
+            _make_ranked("Carol", commit_count=1),
+        ]
+        parsed = json.loads(_build_contributor_timeline_chart(commits, ranked))
+        assert len(parsed["data"]) == 3
+
+    def test_xaxis_type_is_category(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 3, 11), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 18), email="bob@example.com"),
+        ]
+        ranked = [
+            _make_ranked("Alice", commit_count=1),
+            _make_ranked("Bob", commit_count=1),
+        ]
+        parsed = json.loads(_build_contributor_timeline_chart(commits, ranked))
+        assert parsed["layout"]["xaxis"]["type"] == "category"
+
+    def test_layout_does_not_contain_bgcolor_keys(self) -> None:
+        commits = [
+            _make_commit(datetime.date(2024, 3, 11), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 18), email="bob@example.com"),
+        ]
+        ranked = [
+            _make_ranked("Alice", commit_count=1),
+            _make_ranked("Bob", commit_count=1),
+        ]
+        parsed = json.loads(_build_contributor_timeline_chart(commits, ranked))
+        layout = parsed["layout"]
+        assert "paper_bgcolor" not in layout
+        assert "plot_bgcolor" not in layout
+
+    def test_script_closing_tag_is_escaped(self) -> None:
+        """A contributor name containing </script> must not appear raw in output."""
+        commits = [
+            _make_commit(datetime.date(2024, 3, 11), email="alice@example.com"),
+            _make_commit(datetime.date(2024, 3, 18), email="bob@example.com"),
+        ]
+        injected_stats = ContributorStats(
+            name="</script><script>alert(1)</script>",
+            email="alice@example.com",
+            commit_count=1,
+            lines_added=10,
+            lines_deleted=2,
+            active_days=1,
+            first_commit_date=datetime.date(2024, 1, 1),
+            last_commit_date=datetime.date(2024, 3, 31),
+        )
+        ranked = [
+            RankedContributor(
+                stats=injected_stats,
+                composite_score=1.0,
+                percentile=100.0,
+                tier=7,
+                tier_designation="Commander",
+            ),
+            _make_ranked("Bob", commit_count=1),
+        ]
+        result = _build_contributor_timeline_chart(commits, ranked)
+        assert "</script>" not in result
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The aggregate weekly commit timeline shows total repository activity but
cannot distinguish between contributors who work in concentrated bursts
and those with sustained low-volume engagement. Identifying this pattern
requires inspecting the raw data manually — there is no visual surface
for it in the report.

## Change

Adds a per-contributor weekly commit frequency chart as a new report
section positioned between the aggregate timeline and the contributor
rankings table.

- `_build_contributor_timeline_chart(commits, ranked)` in `renderer.py`
  bins commits by calendar week per contributor email and produces one
  `go.Scatter` trace per contributor. Traces follow the ranked list order
  so the highest-composite-score contributor appears first in the legend.
  Colours are cycled from the existing `_PIE_PALETTE`. Returns `"null"`
  when fewer than two contributors are present or no commits fall within
  the analysis window.
- `_build_charts()` updated to include the `"contributor_timeline"` key.
- `report.html.j2` updated with the new section, `spec-contributor_timeline`
  JSON block, and `"contributor_timeline"` wired into `CHART_IDS`.

## Verification

- 168 tests pass (`pytest -n auto`)
- `mypy src/` clean
- `ruff check src/` clean
- 7 new unit tests in `TestBuildContributorTimelineChart`
- 1 new e2e assertion: `id="spec-contributor_timeline"` present in output