### PR TITLE
docs/v0.5.0-pre-release: align documentation with v0.5.0 feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Reveille is designed for developers, engineering managers, and technical leads w
 **What it produces:**
 
 - Contribution heatmap with a GitHub-style year-navigable grid showing per-day commit activity. Year tabs allow switching between calendar years; a contributor dropdown surfaces per-contributor views alongside the aggregated default.
-- Commit frequency timelines and rolling activity charts
+- Aggregate weekly commit timeline and per-contributor commit frequency chart, enabling direct comparison of burst contributors versus contributors with sustained low-volume engagement across the analysis window
 - Per-contributor breakdowns covering commits, lines added and removed, and active day counts
 - A structured ranking table assigning each contributor a tier designation based on weighted activity metrics
 - Repository health indicators including bus factor, longest inactive streak, and consistency scores
@@ -199,6 +199,8 @@ The generated HTML file is structured as a formal report with the following sect
 **Activity Heatmap** — A GitHub-style year-navigable grid showing commit frequency by calendar day. Rows represent days of the week (Monday–Sunday); columns represent calendar weeks. Year tabs derived from the analysis window allow switching between calendar years without regenerating the report. A contributor dropdown provides per-contributor views alongside the aggregated default; single-contributor repositories hide the dropdown automatically.
 
 **Commit Timeline** — A rolling area chart showing commit volume per calendar week over the analysis window. Highlights periods of high and low activity.
+
+**Per-Contributor Commit Frequency** — A multi-trace line chart showing weekly commit frequency for each contributor individually across the analysis window. Each contributor is represented as a separate trace, enabling direct comparison of burst contributors versus those with sustained low-volume engagement — a distinction the aggregate timeline cannot convey.
 
 **Contributor Summary Table** — A ranked table listing each contributor with their commit count, lines added, lines removed, net line delta, active days, most recent commit date, and assigned tier designation.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -36,7 +36,14 @@ contributor's identity is keyed on their author email address, not their
 display name. This means that a contributor who has committed under two
 different names — common after a name change or when work and personal
 accounts are mixed — is correctly treated as a single person, using the
-name from their most recent commit.
+name from their most recent commit. If a `.mailmap` file is present at
+the repository root, email aliases are resolved to their canonical
+identity before aggregation. A contributor who has committed under
+multiple email addresses is unified under the canonical identity declared
+in `.mailmap`, ensuring that ranking and contribution metrics reflect
+actual individual output rather than the number of addresses used. The
+four-field `.mailmap` form is not yet supported and is documented as a
+known limitation.
 
 Third, each contributor is scored using the weighted composite ranking
 algorithm and assigned a tier designation relative to the other


### PR DESCRIPTION
## Summary

Two features shipped in the current unreleased cycle —
per-contributor commit frequency chart and `.mailmap` alias
resolution — were not reflected in the user-facing documentation.
This PR closes all three identified gaps before the v0.5.0 release.

## Changes

- `README.md` Overview: per-contributor timeline named as a distinct
  chart type alongside the aggregate timeline.
- `README.md` Output Description: per-contributor commit frequency
  chart added as an explicit named section.
- `docs/USER_GUIDE.md` How Reveille Works: identity resolution
  paragraph extended to cover `.mailmap` email alias resolution
  and its current four-field form limitation.

## Test plan

Documentation-only. No code changes. CI lint and typecheck pass.