### PR TITLE
chore/pypi-classifier-upgrade: upgrade PyPI classifier to Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   Hooks now execute inside the project's Poetry virtualenv, ensuring exact
   version parity with the CI pipeline and eliminating the `additional_dependencies`
   maintenance burden in the mirror-based hook configuration.
+- PyPI development status classifier updated from `3 - Alpha` to `4 - Beta`.
+  Added `Intended Audience :: Information Technology` and
+  `Topic :: Software Development :: Build Tools` classifiers.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ keywords = [
     "devtools",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
@@ -35,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Version Control :: Git",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Build Tools",
     "Topic :: Utilities",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
## Summary

At v0.5.0 with 173 passing tests, strict mypy, documented semantics,
and six published releases, the `3 - Alpha` classifier is no longer
an accurate signal. This PR upgrades to `4 - Beta` and adds two
classifiers that improve discoverability for enterprise evaluators.

## Changes

- `pyproject.toml`: Development Status upgraded to `4 - Beta`.
  Added `Intended Audience :: Information Technology` and
  `Topic :: Software Development :: Build Tools`.
- `CHANGELOG.md`: Changed entry added to `[Unreleased]`.

## Test plan

Packaging metadata only. CI passes.