### PR TITLE
chore/release-v0.5.0: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] — 2026-05-19
+
 ### Added
 
 - `.mailmap` alias resolution applied in `GitReader` before contributor
@@ -299,7 +303,8 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.5.0
 [0.4.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.4.1
 [0.4.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.4.0
 [0.3.3]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.3.3

--- a/README.md
+++ b/README.md
@@ -333,17 +333,7 @@ ruff check src/
 
 ## Contributing
 
-Contributions are welcome. Before opening a pull request, please read the following.
-
-**Reporting issues.** Use GitHub Issues. Include the output of `reveille --version`, the operating system, Python version, and a minimal reproduction case. If the issue involves a specific repository, a sanitised `git log --oneline` covering the relevant range is sufficient — do not include source code.
-
-**Proposing changes.** Open an issue before starting significant work. This avoids duplication and ensures the direction is aligned before effort is invested.
-
-**Submitting pull requests.** All pull requests must target the `main` branch. The CI pipeline runs `ruff`, `mypy`, and `pytest` on every pull request. All three must pass. New public functions require docstrings. New behaviour requires tests. The output contract — single self-contained HTML file, no external calls, formal aesthetic — is non-negotiable and must be preserved in every contribution.
-
-**Code style.** Ruff handles linting and import ordering. Mypy runs in strict mode. Type annotations are required on every function signature. Early returns are preferred over nested conditionals throughout.
-
-**Commit messages.** Follow the Conventional Commits specification: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`. Scope is optional but encouraged, e.g. `feat(ranking): add recency decay weighting`.
+Contributions are welcome. Please read [CONTRIBUTING.md](https://github.com/varaprasadchilakanti/reveille/blob/main/CONTRIBUTING.md) before opening a pull request. It covers the development environment setup, architecture overview, pull request contract, code style requirements, and commit message conventions.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current stable release receives security fixes.
 
 | Version | Supported |
 |---------|-----------|
-| 0.4.x   | ✓         |
-| < 0.4.0 | ✗         |
+| 0.5.x   | ✓         |
+| < 0.5.0 | ✗         |
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.4.1"
+version = "0.5.0"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Varaprasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
### Added

- `.mailmap` alias resolution applied in `GitReader` before contributor
  aggregation. Contributors who have committed under multiple email
  addresses are now correctly unified under their canonical identity
  as declared in `.mailmap`. Repositories without a `.mailmap` file
  are unaffected. The four-field `.mailmap` form is not yet supported
  and is documented as a known limitation.
- Per-contributor weekly commit frequency chart added as a new report
  section between the aggregate commit timeline and the contributor
  rankings table. Each contributor is represented as a separate trace,
  enabling direct comparison of burst contributors versus sustained
  low-volume engagement across the analysis window.

### Changed

- Pre-commit hooks for ruff and mypy converted to `repo: local` configuration.
  Hooks now execute inside the project's Poetry virtualenv, ensuring exact
  version parity with the CI pipeline and eliminating the `additional_dependencies`
  maintenance burden in the mirror-based hook configuration.
- PyPI development status classifier updated from `3 - Alpha` to `4 - Beta`.
  Added `Intended Audience :: Information Technology` and
  `Topic :: Software Development :: Build Tools` classifiers.

### Fixed

- `validate` command now implements its documented contract in full. In
  addition to confirming the target path is a readable Git repository, it
  verifies that at least one commit is reachable on the default branch.
  Repositories with no commits exit with a non-zero status and a diagnostic
  message, making the command reliable for CI pre-flight checks.