### PR TITLE
chore/fix-version-constant: fix __version__ constant and add version sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
         run: poetry install --no-interaction
       - name: Run ruff
         run: poetry run ruff check src tests
+      - name: Check version sync
+        run: make check-version
 
   typecheck:
     name: Type Check (mypy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
+## [0.5.1] — 2026-05-26
+
+### Fixed
+
+- Internal `__version__` constant corrected to `"0.5.1"`. The v0.5.0 release
+  was published with the constant still reading `"0.4.1"`, causing
+  `reveille --version` to report the wrong version despite the correct package
+  metadata being present on PyPI. A `check-version` Makefile target has been
+  added to the `ci` recipe to enforce parity between `pyproject.toml` and
+  `__init__.__version__` on every future pull request.
+
+---
+
 ## [0.5.0] — 2026-05-19
 
 ### Added
@@ -303,7 +316,8 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.5.1
 [0.5.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.5.0
 [0.4.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.4.1
 [0.4.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.4.0

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ help:  ## Display available targets
 install:  ## Install all dependencies including dev group
 	poetry install
 
+check-version:  ## Assert pyproject.toml version matches reveille.__version__
+	@TOML_VER=$$(poetry version --short); \
+	CODE_VER=$$(poetry run python -c "import reveille; print(reveille.__version__)"); \
+	if [ "$$TOML_VER" != "$$CODE_VER" ]; then \
+		echo "Version mismatch: pyproject.toml=$$TOML_VER, __init__.py=$$CODE_VER"; \
+		exit 1; \
+	fi
+
 # ------------------------------------------------------------------
 # Code Quality
 # ------------------------------------------------------------------
@@ -66,6 +74,7 @@ coverage:  ## Generate HTML and terminal coverage report
 # ------------------------------------------------------------------
 
 ci:  ## Full CI workflow: lint, typecheck, test
+	$(MAKE) check-version
 	$(MAKE) lint
 	$(MAKE) typecheck
 	$(MAKE) test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.5.0"
+version = "0.5.1"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Varaprasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "MIT"

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -4,7 +4,7 @@ A CLI tool that generates self-contained HTML performance reports
 from local Git repositories.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.1"
 __author__ = "Varaprasad Chilakanti"
 __email__ = "varaprasadchilakanti@gmail.com"
 __licence__ = "MIT"


### PR DESCRIPTION
## Summary

The v0.5.0 release was published with `__version__ = "0.4.1"` in
`src/reveille/__init__.py`. The constant was not bumped as part of the
release commit, causing `reveille --version` to report the wrong version
despite correct package metadata on PyPI. PyPI does not permit
re-uploading to the same version string, so this ships as v0.5.1.

A `check-version` target has been added to the Makefile and wired into
the `ci` target. The same check runs as a step in the CI lint job,
ensuring `pyproject.toml` and `__init__.__version__` are in sync on
every pull request as we advance.

## Changes

- `src/reveille/__init__.py`: `__version__` bumped to `"0.5.1"`.
- `pyproject.toml`: version bumped to `"0.5.1"`.
- `Makefile`: `check-version` target added, wired into `ci`.
- `.github/workflows/ci.yml`: `make check-version` step added to lint job.
- `CHANGELOG.md`: `[0.5.1]` entry added, comparison links updated.
