### PR TITLE
chore/github-hygiene: add CodeQL and OpenSSF Scorecard workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+# ==================================================================
+# Reveille -- CodeQL Security Analysis
+#
+# Runs on every push and pull request targeting main, and weekly
+# on Monday. Scans Python source for security vulnerabilities and
+# publishes findings to the repository Security tab.
+# ==================================================================
+
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+# ==================================================================
+# Reveille -- OpenSSF Scorecard
+#
+# Runs on every push to main and weekly on Monday. Scores the
+# repository security posture across branch protection, CI coverage,
+# dependency pinning, vulnerability disclosure, and code review
+# enforcement. Publishes results to the Security tab and to the
+# OpenSSF API, enabling the Scorecard badge.
+# ==================================================================
+
+name: Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary

Adds two security workflows with no impact on the build or test pipeline.

**CodeQL** — GitHub's static analysis engine scans Python source on
every PR and push to main. Findings appear in the Security tab.
Directly relevant to the path handling and chart label embedding
documented in SECURITY.md. `security-extended` query suite covers
injection, path traversal, and unsafe deserialization.

**OpenSSF Scorecard** — scores the repository security posture on
every push to main and weekly. Publishes results to the OpenSSF API,
enabling the Scorecard badge. Recognized by enterprise procurement
and security review teams as an objective third-party signal.

## Changes

- `.github/workflows/codeql.yml`: CodeQL analysis on push, PR, weekly.
- `.github/workflows/scorecard.yml`: Scorecard on push to main, weekly.

## Post-merge note

After the first Scorecard run completes, retrieve the badge URL from
the Security tab and add it to README.md in the docs/v0.6.0-pre-release
branch.

## Test plan

No source changes. CI lint, typecheck, and test jobs unaffected.