### PR TITLE
fix/output-path-validation: harden --output path resolution against traversal and boundary escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   skipped without error; `.mailmap` is a Git-native file and its presence is not
   treated as a conflict.
 
+### Changed
+
+- CodeQL security scanning and OpenSSF Scorecard workflows added to the repository.
+  CodeQL scans Python source on every pull request and push to main. Scorecard
+  publishes an automated security health score to the OpenSSF API on every push
+  to main, enabling the Scorecard badge and providing a verifiable third-party
+  security signal for enterprise evaluators.
+
+### Fixed
+
+- `--output` path resolution hardened against upward traversal sequences.
+  Paths containing `..` components are rejected at the CLI boundary with a
+  non-zero exit and an actionable diagnostic. Resolved output paths that fall
+  outside the repository root emit a stderr warning rather than an error,
+  making cross-boundary writes auditable in CI environments without restricting
+  legitimate use cases such as writing reports to a shared output directory.
+
 ---
 
 ## [0.5.1] — 2026-05-26

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -170,6 +170,37 @@ def _resolve_output_path(output: Path, repo_path: Path) -> Path:
     return output
 
 
+def _validate_output_path(output: Path, repo_path: Path) -> None:
+    """Validate the output path for traversal components and boundary awareness.
+
+    Rejects paths containing upward traversal components before resolution.
+    Emits a stderr warning when the resolved output path falls outside the
+    repository root, making cross-boundary writes auditable in CI without
+    restricting legitimate use.
+
+    Args:
+        output: The output path as provided by the user (pre-resolution).
+        repo_path: The resolved repository root used as the boundary reference.
+
+    Raises:
+        typer.Exit: With code 1 if the path contains upward traversal components.
+    """
+    if ".." in output.parts:
+        typer.echo(
+            f"Error: output path '{output}' contains upward traversal components. "
+            "Provide an absolute path or a path relative to the current directory.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not output.resolve().is_relative_to(repo_path):
+        typer.echo(
+            f"Warning: output path resolves outside the repository root "
+            f"'{repo_path}'. Verify this is intentional.",
+            err=True,
+        )
+
+
 def _merge_cli_flags(
     config_kwargs: ReportConfigKwargs,
     repo: Path,
@@ -309,6 +340,8 @@ def generate(
         no_ranking,
     )
 
+    _validate_output_path(output, repo.resolve())
+
     try:
         report_config = ReportConfig(**merged)
     except ValueError as exc:
@@ -404,6 +437,8 @@ def init(
             err=True,
         )
         raise typer.Exit(code=1)
+
+    _validate_output_path(output, cwd)
 
     from reveille.init import write_init_config, write_mailmap_template
 

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -571,6 +571,44 @@ class TestGenerateCommand:
         assert result.exit_code == 1
         assert "reveille init --force" in result.output
 
+    def test_output_path_outside_repo_root_emits_warning(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """An output path outside the repository root emits a warning but succeeds."""
+        outside_dir = tmp_path_factory.mktemp("outside_output")
+        output = outside_dir / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Warning" in result.output
+
+    def test_output_path_with_traversal_in_stem_is_rejected(
+        self,
+        e2e_repo: Path,
+    ) -> None:
+        """An output path containing upward traversal components exits nonzero."""
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                "../../traversal-report.html",
+            ],
+        )
+        assert result.exit_code == 1
+
 
 # ------------------------------------------------------------------
 # Init command


### PR DESCRIPTION
## Summary

`--output` accepted arbitrary paths without normalisation. In CI
environments where Reveille runs with elevated permissions, a path
containing upward traversal components (`..`) could direct output
outside the intended boundary. This PR adds `_validate_output_path`
applied to `--output` in both `generate` and `init`.

Traversal sequences are rejected at the CLI boundary with a non-zero
exit and an actionable diagnostic. Resolved paths outside the
repository root emit a stderr warning rather than an error — the
behaviour is permitted but surfaced explicitly so CI log aggregators
can detect unintentional cross-boundary writes.

## Changes

- `src/reveille/cli.py`: `_validate_output_path` helper applied to
  `generate` and `init`.
- `tests/e2e/test_cli.py`: two new assertions in `TestGenerateCommand`.
- `CHANGELOG.md`: Fixed entry added, Changed entry added for
  `chore/github-hygiene` (previously missing), section order corrected
  to match Keep a Changelog convention.

## Test plan

`make ci` passes. 186 tests green.