### PR TITLE
fix/chart-label-sanitisation: sanitise contributor names before Plotly trace embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   outside the repository root emit a stderr warning rather than an error,
   making cross-boundary writes auditable in CI environments without restricting
   legitimate use cases such as writing reports to a shared output directory.
+- Contributor display names and other user-controlled strings sourced from Git
+  commit metadata are now sanitised before embedding as Plotly trace labels.
+  HTML tags are stripped via a compiled regex, null bytes are removed, and
+  surrounding whitespace is trimmed. Content-safe characters (ampersands,
+  parentheses, hyphens, apostrophes) are preserved. Applied at every trace
+  embedding site across all chart builders and the heatmap payload.
 
 ---
 

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -65,6 +66,9 @@ _PIE_PALETTE: list[str] = [
     "#6366f1",
     "#f97316",
 ]
+
+# Pre-compiled pattern for stripping HTML tags from user-controlled strings.
+_HTML_TAG_RE: re.Pattern[str] = re.compile(r"<[^>]+>")
 
 # Module-level cache for the Plotly JS bundle.
 # plotly.offline.get_plotlyjs() reads ~3.5 MB of minified JavaScript from
@@ -313,7 +317,7 @@ def _build_contributor_timeline_chart(
                 x=all_weeks,
                 y=counts,
                 mode="lines",
-                name=r.stats.name,
+                name=_sanitise_chart_label(r.stats.name),
                 line={"color": _PIE_PALETTE[i % len(_PIE_PALETTE)], "width": 2},
                 hovertemplate="Week of %{x}<br>Commits: %{y}<extra></extra>",
             )
@@ -387,7 +391,7 @@ def _build_heatmap_data(
     for r in ranked_contributors:
         email_key = r.stats.email.lower()
         if email_key in per_email:
-            contributors.append({"email": email_key, "name": r.stats.name})
+            contributors.append({"email": email_key, "name": _sanitise_chart_label(r.stats.name)})
             daily_counts[email_key] = dict(per_email[email_key])
 
     payload: dict[str, object] = {
@@ -413,7 +417,7 @@ def _build_contributor_commits_chart(ranked: list[RankedContributor]) -> str:
     if not ranked:
         return "null"
 
-    names = [r.stats.name for r in reversed(ranked)]
+    names = [_sanitise_chart_label(r.stats.name) for r in reversed(ranked)]
     counts = [r.stats.commit_count for r in reversed(ranked)]
     tiers = [r.tier_designation for r in reversed(ranked)]
 
@@ -449,7 +453,7 @@ def _build_contributor_lines_chart(ranked: list[RankedContributor]) -> str:
     if not ranked:
         return "null"
 
-    names = [r.stats.name for r in ranked]
+    names = [_sanitise_chart_label(r.stats.name) for r in ranked]
     added = [r.stats.lines_added for r in ranked]
     deleted = [r.stats.lines_deleted for r in ranked]
 
@@ -501,7 +505,9 @@ def _build_commit_share_pie(ranked: list[RankedContributor]) -> str:
         return "null"
 
     sorted_r = sorted(ranked, key=lambda r: r.stats.commit_count, reverse=True)
-    labels, values = _aggregate_pie_data([(r.stats.name, r.stats.commit_count) for r in sorted_r])
+    labels, values = _aggregate_pie_data(
+        [(_sanitise_chart_label(r.stats.name), r.stats.commit_count) for r in sorted_r]
+    )
 
     fig = go.Figure(
         go.Pie(
@@ -540,7 +546,9 @@ def _build_lines_share_pie(ranked: list[RankedContributor]) -> str:
         return "null"
 
     sorted_r = sorted(ranked, key=lambda r: r.stats.lines_changed, reverse=True)
-    labels, values = _aggregate_pie_data([(r.stats.name, r.stats.lines_changed) for r in sorted_r])
+    labels, values = _aggregate_pie_data(
+        [(_sanitise_chart_label(r.stats.name), r.stats.lines_changed) for r in sorted_r]
+    )
 
     fig = go.Figure(
         go.Pie(
@@ -632,6 +640,29 @@ def _compute_longest_inactive_streak(
 # ------------------------------------------------------------------
 # Chart helper utilities
 # ------------------------------------------------------------------
+
+
+def _sanitise_chart_label(value: str) -> str:
+    """Strip HTML tags, null bytes, and surrounding whitespace from a chart label.
+
+    Contributor names are sourced from Git commit metadata and must not carry
+    HTML tags into Plotly trace fields. _to_json escapes </script> sequences,
+    but raw HTML tags in label text can produce unexpected browser rendering.
+    This function removes them before trace construction.
+
+    Preserves all characters legitimate in contributor names: letters, digits,
+    spaces, hyphens, apostrophes, periods, ampersands, and parentheses.
+
+    Args:
+        value: The raw string to sanitise.
+
+    Returns:
+        The sanitised string with HTML tags stripped, null bytes removed,
+        and surrounding whitespace trimmed.
+    """
+    value = _HTML_TAG_RE.sub("", value)
+    value = value.replace("\x00", "")
+    return value.strip()
 
 
 def _aggregate_pie_data(

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -67,7 +67,13 @@ _PIE_PALETTE: list[str] = [
     "#f97316",
 ]
 
-# Pre-compiled pattern for stripping HTML tags from user-controlled strings.
+# Pre-compiled patterns for sanitising user-controlled strings.
+# _SCRIPT_BLOCK_RE removes script elements including their content before
+# _HTML_TAG_RE strips remaining tags, preventing script body text from
+# surviving as raw output after tag removal.
+_SCRIPT_BLOCK_RE: re.Pattern[str] = re.compile(
+    r"<script[^>]*>.*?</script>", re.IGNORECASE | re.DOTALL
+)
 _HTML_TAG_RE: re.Pattern[str] = re.compile(r"<[^>]+>")
 
 # Module-level cache for the Plotly JS bundle.
@@ -660,6 +666,7 @@ def _sanitise_chart_label(value: str) -> str:
         The sanitised string with HTML tags stripped, null bytes removed,
         and surrounding whitespace trimmed.
     """
+    value = _SCRIPT_BLOCK_RE.sub("", value)
     value = _HTML_TAG_RE.sub("", value)
     value = value.replace("\x00", "")
     return value.strip()

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -27,6 +27,7 @@ from reveille.adapters.renderer import (
     _build_timeline_chart,
     _compute_bus_factor,
     _compute_longest_inactive_streak,
+    _sanitise_chart_label,
     _to_json,
 )
 from reveille.domain.models import Commit, ContributorStats, RankedContributor
@@ -193,6 +194,32 @@ class TestComputeLongestInactiveStreak:
 # ------------------------------------------------------------------
 # _build_timeline_chart
 # ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSanitiseChartLabel:
+    """Tests for the _sanitise_chart_label helper."""
+
+    def test_plain_string_passes_through_unchanged(self) -> None:
+        assert _sanitise_chart_label("Alice Smith") == "Alice Smith"
+
+    def test_html_tag_stripped(self) -> None:
+        assert _sanitise_chart_label("Alice <b>Smith</b>") == "Alice Smith"
+
+    def test_script_tag_stripped(self) -> None:
+        assert _sanitise_chart_label("<script>alert(1)</script>Alice") == "Alice"
+
+    def test_null_byte_stripped(self) -> None:
+        assert _sanitise_chart_label("Alice\x00Smith") == "AliceSmith"
+
+    def test_surrounding_whitespace_trimmed(self) -> None:
+        assert _sanitise_chart_label("  Alice  ") == "Alice"
+
+    def test_ampersand_preserved(self) -> None:
+        assert _sanitise_chart_label("Alice & Bob") == "Alice & Bob"
+
+    def test_parentheses_preserved(self) -> None:
+        assert _sanitise_chart_label("Alice (Smith)") == "Alice (Smith)"
 
 
 @pytest.mark.unit
@@ -444,6 +471,27 @@ class TestBuildContributorCommitsChart:
             _make_ranked("Carol", commit_count=5),
         ]
         assert _is_valid_chart_json(_build_contributor_commits_chart(ranked))
+
+    @pytest.mark.parametrize(
+        "injected_name,expected_absent",
+        [
+            ("<b>Alice</b>", "<b>"),
+            ("<script>alert(1)</script>Alice", "<script>"),
+            ("Alice\x00Smith", "\x00"),
+        ],
+    )
+    def test_html_injection_stripped_from_labels(
+        self,
+        injected_name: str,
+        expected_absent: str,
+    ) -> None:
+        """User-controlled strings containing HTML must not appear raw in chart output."""
+        ranked = [
+            _make_ranked(injected_name, commit_count=10),
+            _make_ranked("Bob", commit_count=5),
+        ]
+        result = _build_contributor_commits_chart(ranked)
+        assert expected_absent not in result
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Chart data is embedded via `| safe` in the Jinja2 template. While
`</script>` sequences are escaped by `_to_json`, contributor display
names containing HTML tags were passed into Plotly trace fields without
sanitisation. This PR adds `_sanitise_chart_label` applied at every
trace embedding site. Content-safe characters are preserved; only HTML
tags, null bytes, and surrounding whitespace are removed.

## Changes

- `src/reveille/adapters/renderer.py`: `_HTML_TAG_RE` constant,
  `_sanitise_chart_label` applied across all chart builders and the
  heatmap payload.
- `tests/unit/adapters/test_renderer.py`: `TestSanitiseChartLabel`
  and parametrised injection assertions on `TestBuildContributorCommitsChart`.
- `CHANGELOG.md`: Fixed entry added.

## Test plan

`make ci` passes. All tests green.