### PR TITLE
feat/structured-progress: introduce ProgressEvent for typed pipeline observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   `--force` applies to both generated files. An existing `.mailmap` is silently
   skipped without error; `.mailmap` is a Git-native file and its presence is not
   treated as a conflict.
+- `ProgressEvent` frozen dataclass introduced in `reveille.domain.models`.
+  The pipeline progress callback signature changes from `Callable[[str], None]`
+  to `Callable[[ProgressEvent], None]`. Each event carries the incoming stage
+  label, elapsed time of the stage that just completed, and an optional
+  items-processed count (commit count at the reading stage). The CLI stage
+  spinner now displays per-stage elapsed time on completion lines. The service
+  layer remains terminal-agnostic.
 
 ### Changed
 

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -15,6 +15,7 @@ import datetime
 import itertools
 import sys
 import threading
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, cast
@@ -23,6 +24,7 @@ import typer
 
 from reveille import __version__
 from reveille.config import ReportConfig, ReportConfigKwargs
+from reveille.domain.models import ProgressEvent
 from reveille.exceptions import ConfigurationError, RevelleError
 
 app = typer.Typer(
@@ -73,6 +75,9 @@ class _StageSpinner:
         self._stop_event: threading.Event = threading.Event()
         self._thread: threading.Thread | None = None
         self._label: str = ""
+        self._elapsed_seconds: float = 0.0
+        self._items_processed: int | None = None
+        self._start_time: float = 0.0
 
     def begin(self, label: str) -> None:
         """Start the animated indicator for a new pipeline stage.
@@ -81,18 +86,35 @@ class _StageSpinner:
             label: Human-readable stage name written to stderr.
         """
         self._label = label
+        self._elapsed_seconds = 0.0
+        self._items_processed = None
+        self._start_time = time.monotonic()
         self._stop_event.clear()
         self._active = True
         self._thread = threading.Thread(target=self._run, args=(label,), daemon=True)
         self._thread.start()
 
-    def complete(self) -> None:
+    def complete(
+        self,
+        elapsed_seconds: float | None = None,
+        items_processed: int | None = None,
+    ) -> None:
         """Stop the current animation and write the completion line.
 
         No-op if begin() has not been called or if already completed.
+
+        Args:
+            elapsed_seconds: Elapsed time to display. When None, computed
+                from the spinner's own start time.
+            items_processed: Optional item count appended to the completion
+                line (e.g. commit count from the reading stage).
         """
         if not self._active:
             return
+        self._elapsed_seconds = (
+            elapsed_seconds if elapsed_seconds is not None else time.monotonic() - self._start_time
+        )
+        self._items_processed = items_processed
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join()
@@ -104,15 +126,20 @@ class _StageSpinner:
             sys.stderr.flush()
             if self._stop_event.wait(0.2):
                 break
-        sys.stderr.write(f"\r  {label} ...   done\n")
+        elapsed = self._elapsed_seconds
+        if self._items_processed is not None:
+            suffix = f"({elapsed:.1f}s, {self._items_processed:,} commits)"
+        else:
+            suffix = f"({elapsed:.1f}s)"
+        sys.stderr.write(f"\r  {label} ...   done {suffix}\n")
         sys.stderr.flush()
 
 
-def _make_progress_callback(spinner: _StageSpinner) -> Callable[[str], None]:
+def _make_progress_callback(spinner: _StageSpinner) -> Callable[[ProgressEvent], None]:
     """Return a progress callback that drives the given spinner.
 
-    On each invocation, completes the previous stage animation and
-    starts a new one for the incoming label.
+    On each invocation, completes the previous stage animation with timing
+    from the event and starts a new one for the incoming stage label.
 
     Args:
         spinner: The _StageSpinner instance to drive.
@@ -121,9 +148,9 @@ def _make_progress_callback(spinner: _StageSpinner) -> Callable[[str], None]:
         A callable suitable for passing as on_progress to generate_report.
     """
 
-    def _callback(label: str) -> None:
-        spinner.complete()
-        spinner.begin(label)
+    def _callback(event: ProgressEvent) -> None:
+        spinner.complete(event.elapsed_seconds, event.items_processed)
+        spinner.begin(event.stage)
 
     return _callback
 

--- a/src/reveille/domain/models.py
+++ b/src/reveille/domain/models.py
@@ -84,6 +84,20 @@ class RepositoryMetadata:
     generated_at: datetime.datetime
 
 
+@dataclass(frozen=True)
+class ProgressEvent:
+    """A pipeline progress notification emitted at each stage boundary.
+
+    Carries the name of the stage that is starting, the elapsed time
+    of the stage that just completed, and an optional item count from
+    the completed stage.
+    """
+
+    stage: str
+    elapsed_seconds: float
+    items_processed: int | None = None
+
+
 @dataclass
 class ReportData:
     """The complete structured dataset for a single report.

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -17,6 +17,7 @@ or Typer. All external concerns are delegated to adapters.
 from __future__ import annotations
 
 import datetime
+import time
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
@@ -24,21 +25,22 @@ from pathlib import Path
 from reveille.adapters.git_reader import GitReader
 from reveille.adapters.renderer import Renderer
 from reveille.config import ReportConfig
-from reveille.domain.models import RankedContributor, ReportData
+from reveille.domain.models import ProgressEvent, RankedContributor, ReportData
 from reveille.domain.ranking import rank_contributors
 
 
 def generate_report(
     config: ReportConfig,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: Callable[[ProgressEvent], None] | None = None,
 ) -> Path:
     """Generate a self-contained HTML performance report.
 
     Args:
         config: Validated report configuration produced by the CLI layer.
-        on_progress: Optional callable invoked with a stage label string
-            at the start of each pipeline stage. Intended for CLI progress
-            display. Has no effect on the output when omitted.
+        on_progress: Optional callable invoked with a ProgressEvent at each
+            pipeline stage boundary. Carries the incoming stage label, elapsed
+            time of the stage that just completed, and an optional item count.
+            Has no effect on the output when omitted.
 
     Returns:
         The absolute path of the written HTML file.
@@ -50,9 +52,10 @@ def generate_report(
         RenderError: If the HTML template fails to render.
     """
     reader = GitReader(config.repo_path)
+    stage_start = time.monotonic()
 
     if on_progress is not None:
-        on_progress("Reading commit history")
+        on_progress(ProgressEvent(stage="Reading commit history", elapsed_seconds=0.0))
     commits = reader.read_commits(
         branch=config.branch,
         since=config.since,
@@ -65,17 +68,29 @@ def generate_report(
     )
     window_end = config.until or datetime.date.today()
 
+    elapsed = time.monotonic() - stage_start
+    stage_start = time.monotonic()
+
     if on_progress is not None:
-        on_progress("Aggregating contributor statistics")
+        on_progress(
+            ProgressEvent(
+                stage="Aggregating contributor statistics",
+                elapsed_seconds=elapsed,
+                items_processed=len(commits),
+            )
+        )
     contributor_stats = reader.aggregate_contributor_stats(
         commits=commits,
         min_commits=config.min_commits,
     )
 
+    elapsed = time.monotonic() - stage_start
+    stage_start = time.monotonic()
+
     ranked_contributors: list[RankedContributor]
     if config.ranking_enabled and contributor_stats:
         if on_progress is not None:
-            on_progress("Ranking contributors")
+            on_progress(ProgressEvent(stage="Ranking contributors", elapsed_seconds=elapsed))
         ranked_contributors = rank_contributors(
             contributors=contributor_stats,
             commits=commits,
@@ -83,6 +98,7 @@ def generate_report(
             window_start=window_start,
             window_end=window_end,
         )
+        elapsed = time.monotonic() - stage_start
     else:
         ranked_contributors = [
             RankedContributor(
@@ -94,6 +110,9 @@ def generate_report(
             )
             for s in contributor_stats
         ]
+
+    if on_progress is not None:
+        on_progress(ProgressEvent(stage="Rendering report", elapsed_seconds=elapsed))
 
     metadata = reader.read_metadata(
         total_commits=len(commits),
@@ -110,7 +129,5 @@ def generate_report(
         commits=commits,
     )
 
-    if on_progress is not None:
-        on_progress("Rendering report")
     renderer = Renderer()
     return renderer.render(report_data, config.output_path)

--- a/tests/unit/services/test_report.py
+++ b/tests/unit/services/test_report.py
@@ -18,6 +18,7 @@ from reveille.config import ReportConfig
 from reveille.domain.models import (
     Commit,
     ContributorStats,
+    ProgressEvent,
     RankedContributor,
     ReportData,
     RepositoryMetadata,
@@ -296,10 +297,10 @@ class TestGenerateReport:
         sample_metadata: RepositoryMetadata,
     ) -> None:
         """on_progress is called once per pipeline stage in execution order."""
-        calls: list[str] = []
+        events: list[ProgressEvent] = []
 
-        def capture(label: str) -> None:
-            calls.append(label)
+        def capture(event: ProgressEvent) -> None:
+            events.append(event)
 
         with (
             patch("reveille.services.report.GitReader") as mock_reader,
@@ -315,9 +316,41 @@ class TestGenerateReport:
 
             generate_report(minimal_config, on_progress=capture)
 
-        assert calls == [
+        assert [e.stage for e in events] == [
             "Reading commit history",
             "Aggregating contributor statistics",
             "Ranking contributors",
             "Rendering report",
         ]
+
+    def test_progress_event_carries_elapsed_time(
+        self,
+        minimal_config: ReportConfig,
+        sample_commit: Commit,
+        sample_stats: ContributorStats,
+        sample_ranked: RankedContributor,
+        sample_metadata: RepositoryMetadata,
+    ) -> None:
+        """All events except the first carry non-negative elapsed time."""
+        events: list[ProgressEvent] = []
+
+        def capture(event: ProgressEvent) -> None:
+            events.append(event)
+
+        with (
+            patch("reveille.services.report.GitReader") as mock_reader,
+            patch("reveille.services.report.rank_contributors") as mock_rank,
+            patch("reveille.services.report.Renderer") as mock_renderer,
+        ):
+            reader_instance = mock_reader.return_value
+            reader_instance.read_commits.return_value = [sample_commit]
+            reader_instance.aggregate_contributor_stats.return_value = [sample_stats]
+            reader_instance.read_metadata.return_value = sample_metadata
+            mock_rank.return_value = [sample_ranked]
+            mock_renderer.return_value.render.return_value = Path("out.html")
+
+            generate_report(minimal_config, on_progress=capture)
+
+        assert events[0].elapsed_seconds == pytest.approx(0.0)
+        for event in events[1:]:
+            assert event.elapsed_seconds >= 0.0


### PR DESCRIPTION
## Summary

The pipeline progress callback previously received only a bare string
label with no timing or volume data. `ProgressEvent` replaces it with
a typed frozen dataclass carrying stage label, elapsed time of the
stage that just completed, and an optional items-processed count.
The CLI stage spinner now displays per-stage elapsed time and commit
count on completion lines. The service layer remains terminal-agnostic.

## Changes

- `src/reveille/domain/models.py`: `ProgressEvent` dataclass.
- `src/reveille/services/report.py`: `on_progress` signature updated,
  timing emitted at each stage boundary.
- `src/reveille/cli.py`: `_StageSpinner` and `_make_progress_callback`
  adapted to `ProgressEvent`.
- `tests/unit/services/test_report.py`: existing progress test updated
  to assert on `ProgressEvent.stage`; `test_progress_event_carries_elapsed_time` added.
- `CHANGELOG.md`: Added entry.

## Test plan

`make ci` passes. 197 tests green.