### PR TITLE
feat/json-export: add --format flag with html, json, and both options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   items-processed count (commit count at the reading stage). The CLI stage
   spinner now displays per-stage elapsed time on completion lines. The service
   layer remains terminal-agnostic.
+- `--format` flag added to `reveille generate`. Accepted values are `html`
+  (default, existing behaviour), `json`, and `both`. `--format json` produces
+  a structured JSON file at the same path stem as the HTML output. `--format
+  both` produces both in a single invocation. The JSON payload contains
+  repository metadata, ranked contributor statistics with all scoring fields,
+  and derived health metrics. The raw commits list is excluded. Dates are
+  serialised as ISO 8601 strings.
 
 ### Changed
 

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -157,6 +157,79 @@ class Renderer:
 
         return resolved
 
+    def render_json(self, data: ReportData, output_path: Path) -> Path:
+        """Serialise the report data to a structured JSON file.
+
+        The payload contains repository metadata, ranked contributor statistics
+        with all scoring fields, and derived health metrics. The raw commits
+        list is excluded. Dates are ISO 8601 strings. Suitable for consumption
+        by dashboards, data warehouses, and Jira integrations without parsing
+        HTML.
+
+        Args:
+            data: The complete structured report dataset.
+            output_path: Destination path for the JSON file.
+
+        Returns:
+            The absolute path of the written file.
+
+        Raises:
+            OutputPathError: If the parent directory does not exist or
+                the file cannot be written.
+        """
+        resolved = output_path.resolve()
+        if not resolved.parent.exists():
+            raise OutputPathError(
+                f"Output directory '{resolved.parent}' does not exist. "
+                "Create the directory before generating a report."
+            )
+
+        derived = self._compute_derived_stats(data)
+
+        payload: dict[str, Any] = {
+            "metadata": {
+                "name": data.metadata.name,
+                "remote_url": data.metadata.remote_url,
+                "default_branch": data.metadata.default_branch,
+                "total_commits": data.metadata.total_commits,
+                "unique_contributors": data.metadata.unique_contributors,
+                "analysis_since": data.metadata.analysis_since.isoformat(),
+                "analysis_until": data.metadata.analysis_until.isoformat(),
+                "generated_at": data.metadata.generated_at.isoformat(),
+            },
+            "contributors": [
+                {
+                    "rank": i + 1,
+                    "name": r.stats.name,
+                    "email": r.stats.email,
+                    "tier": r.tier,
+                    "tier_designation": r.tier_designation,
+                    "composite_score": r.composite_score,
+                    "percentile": r.percentile,
+                    "commit_count": r.stats.commit_count,
+                    "lines_added": r.stats.lines_added,
+                    "lines_deleted": r.stats.lines_deleted,
+                    "net_lines": r.stats.net_lines,
+                    "lines_changed": r.stats.lines_changed,
+                    "active_days": r.stats.active_days,
+                    "first_commit_date": r.stats.first_commit_date.isoformat(),
+                    "last_commit_date": r.stats.last_commit_date.isoformat(),
+                }
+                for i, r in enumerate(data.ranked_contributors)
+            ],
+            "derived": {
+                "bus_factor": derived["bus_factor"],
+                "longest_inactive_streak": derived["longest_inactive_streak"],
+            },
+        }
+
+        try:
+            resolved.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        except OSError as exc:
+            raise OutputPathError(f"Failed to write JSON report to '{resolved}': {exc}") from exc
+
+        return resolved
+
     # ------------------------------------------------------------------
     # Derived statistics
     # ------------------------------------------------------------------

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -23,7 +23,7 @@ from typing import Annotated, Any, ClassVar, cast
 import typer
 
 from reveille import __version__
-from reveille.config import ReportConfig, ReportConfigKwargs
+from reveille.config import OutputFormat, ReportConfig, ReportConfigKwargs
 from reveille.domain.models import ProgressEvent
 from reveille.exceptions import ConfigurationError, RevelleError
 
@@ -239,6 +239,7 @@ def _merge_cli_flags(
     exclude_author: list[str] | None,
     min_commits: int | None,
     no_ranking: bool,
+    output_format: str,
 ) -> ReportConfigKwargs:
     """Merge CLI flag values into the base configuration dict.
 
@@ -257,6 +258,7 @@ def _merge_cli_flags(
         exclude_author: List of authors to exclude, or None.
         min_commits: Minimum commit threshold, or None if not provided.
         no_ranking: Whether ranking is disabled.
+        output_format: Output format string. Accepted values: html, json, both.
 
     Returns:
         A merged ReportConfigKwargs ready for ReportConfig construction.
@@ -281,6 +283,7 @@ def _merge_cli_flags(
         merged["min_commits"] = min_commits
     if no_ranking:
         merged["ranking_enabled"] = False
+    merged["output_format"] = cast(OutputFormat, output_format)
 
     return cast(ReportConfigKwargs, merged)
 
@@ -326,6 +329,13 @@ def generate(
         bool,
         typer.Option("--no-ranking", help="Omit the contributor ranking table from the output."),
     ] = False,
+    output_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            help="Output format. Accepted values: html, json, both.",
+        ),
+    ] = "html",
     config: Annotated[
         Path | None,
         typer.Option("--config", "-c", help="Path to a TOML configuration file."),
@@ -365,6 +375,7 @@ def generate(
         exclude_author,
         min_commits,
         no_ranking,
+        output_format,
     )
 
     _validate_output_path(output, repo.resolve())
@@ -377,7 +388,7 @@ def generate(
 
     spinner = _StageSpinner()
     try:
-        written_path = generate_report(
+        written_paths = generate_report(
             report_config,
             on_progress=_make_progress_callback(spinner),
         )
@@ -387,7 +398,8 @@ def generate(
         raise typer.Exit(code=1) from exc
     else:
         spinner.complete()
-        typer.echo(f"Report written to: {written_path}")
+        for path in written_paths:
+            typer.echo(f"Report written to: {path}")
 
 
 @app.command()

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import datetime
 import tomllib
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
 from pydantic import BaseModel, Field, model_validator
 
 from reveille.exceptions import ConfigurationError
+
+OutputFormat = Literal["html", "json", "both"]
 
 
 class RankingWeights(BaseModel):
@@ -70,6 +72,7 @@ class ReportConfig(BaseModel):
     min_commits: int = Field(default=1, ge=1)
     ranking_enabled: bool = Field(default=True)
     ranking_weights: RankingWeights = Field(default_factory=RankingWeights)
+    output_format: OutputFormat = Field(default="html")
 
     @model_validator(mode="after")
     def since_must_precede_until(self) -> ReportConfig:
@@ -109,6 +112,7 @@ class ReportConfigKwargs(TypedDict, total=False):
     min_commits: int
     ranking_enabled: bool
     ranking_weights: RankingWeights
+    output_format: OutputFormat
 
 
 def load_config_from_toml(path: Path) -> ReportConfigKwargs:
@@ -172,6 +176,8 @@ def _parse_report_section(report: dict[str, Any]) -> dict[str, Any]:
                     f"Invalid '{field}' date in configuration file: "
                     f"'{report[field]}'. Expected YYYY-MM-DD."
                 ) from exc
+    if "format" in report:
+        kwargs["output_format"] = cast(OutputFormat, str(report["format"]))
     return kwargs
 
 

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -32,7 +32,7 @@ from reveille.domain.ranking import rank_contributors
 def generate_report(
     config: ReportConfig,
     on_progress: Callable[[ProgressEvent], None] | None = None,
-) -> Path:
+) -> list[Path]:
     """Generate a self-contained HTML performance report.
 
     Args:
@@ -130,4 +130,9 @@ def generate_report(
     )
 
     renderer = Renderer()
-    return renderer.render(report_data, config.output_path)
+    paths: list[Path] = []
+    if config.output_format in ("html", "both"):
+        paths.append(renderer.render(report_data, config.output_path))
+    if config.output_format in ("json", "both"):
+        paths.append(renderer.render_json(report_data, config.output_path.with_suffix(".json")))
+    return paths

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -571,6 +571,53 @@ class TestGenerateCommand:
         assert result.exit_code == 1
         assert "reveille init --force" in result.output
 
+    def test_format_json_produces_json_file(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """--format json writes a .json file at the output stem path."""
+        base = tmp_path_factory.mktemp("format_json")
+        output = base / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(output),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        assert (base / "report.json").exists()
+
+    def test_format_both_produces_html_and_json_files(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """--format both writes both .html and .json files in a single invocation."""
+        base = tmp_path_factory.mktemp("format_both")
+        output = base / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(output),
+                "--format",
+                "both",
+            ],
+        )
+        assert result.exit_code == 0
+        assert output.exists()
+        assert (base / "report.json").exists()
+
     def test_output_path_outside_repo_root_emits_warning(
         self,
         e2e_repo: Path,

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 import datetime
 import json
+from pathlib import Path
 
 import plotly.graph_objects as go
 import pytest
 
 from reveille.adapters.renderer import (
+    Renderer,
     _aggregate_pie_data,
     _build_commit_share_pie,
     _build_contributor_commits_chart,
@@ -30,7 +32,14 @@ from reveille.adapters.renderer import (
     _sanitise_chart_label,
     _to_json,
 )
-from reveille.domain.models import Commit, ContributorStats, RankedContributor
+from reveille.domain.models import (
+    Commit,
+    ContributorStats,
+    RankedContributor,
+    ReportData,
+    RepositoryMetadata,
+)
+from reveille.exceptions import OutputPathError
 
 # ------------------------------------------------------------------
 # Shared factory helpers
@@ -96,6 +105,60 @@ def _is_valid_chart_json(value: str) -> bool:
     except json.JSONDecodeError:
         return False
     return "data" in parsed and "layout" in parsed
+
+
+@pytest.mark.unit
+class TestRenderJson:
+    """Tests for Renderer.render_json."""
+
+    def _renderer(self) -> Renderer:
+        return Renderer()
+
+    def _sample_data(self) -> ReportData:
+        ranked = [_make_ranked("Alice", commit_count=10)]
+        metadata = RepositoryMetadata(
+            name="test-repo",
+            remote_url=None,
+            default_branch="main",
+            total_commits=10,
+            unique_contributors=1,
+            analysis_since=datetime.date(2024, 1, 1),
+            analysis_until=datetime.date(2024, 3, 31),
+            generated_at=datetime.datetime(2024, 4, 1, 12, 0, tzinfo=datetime.UTC),
+        )
+        return ReportData(metadata=metadata, ranked_contributors=ranked, commits=[])
+
+    def test_output_is_valid_json(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.json"
+        self._renderer().render_json(self._sample_data(), output)
+        parsed = json.loads(output.read_text(encoding="utf-8"))
+        assert isinstance(parsed, dict)
+
+    def test_output_contains_expected_top_level_keys(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.json"
+        self._renderer().render_json(self._sample_data(), output)
+        parsed = json.loads(output.read_text(encoding="utf-8"))
+        assert "metadata" in parsed
+        assert "contributors" in parsed
+        assert "derived" in parsed
+
+    def test_dates_serialised_as_iso_strings(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.json"
+        self._renderer().render_json(self._sample_data(), output)
+        metadata = json.loads(output.read_text(encoding="utf-8"))["metadata"]
+        assert metadata["analysis_since"] == "2024-01-01"
+        assert metadata["analysis_until"] == "2024-03-31"
+
+    def test_returns_resolved_absolute_path(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.json"
+        result = self._renderer().render_json(self._sample_data(), output)
+        assert result.is_absolute()
+        assert result == output.resolve()
+
+    def test_raises_output_path_error_on_missing_parent(self, tmp_path: Path) -> None:
+        output = tmp_path / "nonexistent" / "report.json"
+        with pytest.raises(OutputPathError):
+            self._renderer().render_json(self._sample_data(), output)
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/services/test_report.py
+++ b/tests/unit/services/test_report.py
@@ -131,7 +131,7 @@ class TestGenerateReport:
 
             result = generate_report(minimal_config)
 
-        assert result == expected_path
+        assert result == [expected_path]
 
     def test_rank_contributors_called_when_ranking_enabled(
         self,


### PR DESCRIPTION
## Summary

`reveille generate --format json` produces a structured JSON file at
the same path as the HTML output with a `.json` extension. `--format
both` produces both in a single invocation. The JSON payload contains
repository metadata, ranked contributor statistics, and derived metrics,
serialised in a schema suitable for consumption by dashboards, data
warehouses, and Jira integrations without parsing HTML. The raw commits
list is excluded — it is too large to be useful for downstream consumers
and would double the output size for large repositories.

## Changes

- `renderer.py`: `render_json()`.
- `config.py`: `OutputFormat` alias, `output_format` field, TOML key.
- `services/report.py`: dispatch and return type.
- `cli.py`: `--format` flag.
- Tests: `TestRenderJson`, two e2e assertions.
- `CHANGELOG.md`: Added entry.

## Test plan

`make ci` passes. All tests green.