### PR TITLE
feat/csv-export: add csv to --format accepted values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   repository metadata, ranked contributor statistics with all scoring fields,
   and derived health metrics. The raw commits list is excluded. Dates are
   serialised as ISO 8601 strings.
+- `--format csv` added as an accepted output format, producing the ranked
+  contributor table as a UTF-8 CSV file with BOM encoding. BOM ensures correct
+  column rendering in Microsoft Excel on Windows without requiring a manual
+  import wizard. Columns: rank, name, email, designation, tier, commits,
+  lines added, lines deleted, net lines, active days, last commit date,
+  composite score, percentile.
 
 ### Changed
 

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -24,6 +24,7 @@ labels or commit messages contain that sequence.
 
 from __future__ import annotations
 
+import csv
 import datetime
 import json
 import re
@@ -227,6 +228,73 @@ class Renderer:
             resolved.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         except OSError as exc:
             raise OutputPathError(f"Failed to write JSON report to '{resolved}': {exc}") from exc
+
+        return resolved
+
+    def render_csv(self, data: ReportData, output_path: Path) -> Path:
+        """Serialise the ranked contributor table to a UTF-8 CSV file with BOM encoding.
+
+        BOM encoding ensures correct column rendering in Microsoft Excel on
+        Windows without requiring a manual import wizard configuration.
+
+        Args:
+            data: The complete structured report dataset.
+            output_path: Destination path for the CSV file.
+
+        Returns:
+            The absolute path of the written file.
+
+        Raises:
+            OutputPathError: If the parent directory does not exist or
+                the file cannot be written.
+        """
+        resolved = output_path.resolve()
+        if not resolved.parent.exists():
+            raise OutputPathError(
+                f"Output directory '{resolved.parent}' does not exist. "
+                "Create the directory before generating a report."
+            )
+
+        fieldnames = [
+            "rank",
+            "name",
+            "email",
+            "designation",
+            "tier",
+            "commits",
+            "lines_added",
+            "lines_deleted",
+            "net_lines",
+            "active_days",
+            "last_commit_date",
+            "composite_score",
+            "percentile",
+        ]
+
+        try:
+            with resolved.open("w", encoding="utf-8-sig", newline="") as fh:
+                writer = csv.DictWriter(fh, fieldnames=fieldnames)
+                writer.writeheader()
+                for i, r in enumerate(data.ranked_contributors):
+                    writer.writerow(
+                        {
+                            "rank": i + 1,
+                            "name": r.stats.name,
+                            "email": r.stats.email,
+                            "designation": r.tier_designation,
+                            "tier": r.tier,
+                            "commits": r.stats.commit_count,
+                            "lines_added": r.stats.lines_added,
+                            "lines_deleted": r.stats.lines_deleted,
+                            "net_lines": r.stats.net_lines,
+                            "active_days": r.stats.active_days,
+                            "last_commit_date": r.stats.last_commit_date.isoformat(),
+                            "composite_score": r.composite_score,
+                            "percentile": r.percentile,
+                        }
+                    )
+        except OSError as exc:
+            raise OutputPathError(f"Failed to write CSV report to '{resolved}': {exc}") from exc
 
         return resolved
 

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -333,7 +333,7 @@ def generate(
         str,
         typer.Option(
             "--format",
-            help="Output format. Accepted values: html, json, both.",
+            help="Output format. Accepted values: html, json, both, csv.",
         ),
     ] = "html",
     config: Annotated[

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from reveille.exceptions import ConfigurationError
 
-OutputFormat = Literal["html", "json", "both"]
+OutputFormat = Literal["html", "json", "both", "csv"]
 
 
 class RankingWeights(BaseModel):

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -135,4 +135,6 @@ def generate_report(
         paths.append(renderer.render(report_data, config.output_path))
     if config.output_format in ("json", "both"):
         paths.append(renderer.render_json(report_data, config.output_path.with_suffix(".json")))
+    if config.output_format == "csv":
+        paths.append(renderer.render_csv(report_data, config.output_path.with_suffix(".csv")))
     return paths

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -618,6 +618,29 @@ class TestGenerateCommand:
         assert output.exists()
         assert (base / "report.json").exists()
 
+    def test_format_csv_produces_csv_file(
+        self,
+        e2e_repo: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """--format csv writes a .csv file at the output stem path."""
+        base = tmp_path_factory.mktemp("format_csv")
+        output = base / "report.html"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(output),
+                "--format",
+                "csv",
+            ],
+        )
+        assert result.exit_code == 0
+        assert (base / "report.csv").exists()
+
     def test_output_path_outside_repo_root_emits_warning(
         self,
         e2e_repo: Path,

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -10,9 +10,11 @@ completeness, and the behavioural contract for edge cases.
 
 from __future__ import annotations
 
+import csv
 import datetime
 import json
 from pathlib import Path
+from typing import ClassVar
 
 import plotly.graph_objects as go
 import pytest
@@ -159,6 +161,77 @@ class TestRenderJson:
         output = tmp_path / "nonexistent" / "report.json"
         with pytest.raises(OutputPathError):
             self._renderer().render_json(self._sample_data(), output)
+
+
+@pytest.mark.unit
+class TestRenderCsv:
+    """Tests for Renderer.render_csv."""
+
+    _EXPECTED_FIELDNAMES: ClassVar[list[str]] = [
+        "rank",
+        "name",
+        "email",
+        "designation",
+        "tier",
+        "commits",
+        "lines_added",
+        "lines_deleted",
+        "net_lines",
+        "active_days",
+        "last_commit_date",
+        "composite_score",
+        "percentile",
+    ]
+
+    def _renderer(self) -> Renderer:
+        return Renderer()
+
+    def _sample_data(self) -> ReportData:
+        ranked = [
+            _make_ranked("Alice", commit_count=10),
+            _make_ranked("Bob", commit_count=5),
+        ]
+        metadata = RepositoryMetadata(
+            name="test-repo",
+            remote_url=None,
+            default_branch="main",
+            total_commits=15,
+            unique_contributors=2,
+            analysis_since=datetime.date(2024, 1, 1),
+            analysis_until=datetime.date(2024, 3, 31),
+            generated_at=datetime.datetime(2024, 4, 1, 12, 0, tzinfo=datetime.UTC),
+        )
+        return ReportData(metadata=metadata, ranked_contributors=ranked, commits=[])
+
+    def test_header_row_contains_expected_columns(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.csv"
+        self._renderer().render_csv(self._sample_data(), output)
+        with output.open(encoding="utf-8-sig") as fh:
+            reader = csv.DictReader(fh)
+            assert list(reader.fieldnames or []) == self._EXPECTED_FIELDNAMES
+
+    def test_bom_present_at_file_start(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.csv"
+        self._renderer().render_csv(self._sample_data(), output)
+        assert output.read_bytes()[:3] == b"\xef\xbb\xbf"
+
+    def test_correct_row_count(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.csv"
+        self._renderer().render_csv(self._sample_data(), output)
+        with output.open(encoding="utf-8-sig") as fh:
+            rows = list(csv.reader(fh))
+        assert len(rows) == 3  # 1 header + 2 data rows
+
+    def test_returns_resolved_absolute_path(self, tmp_path: Path) -> None:
+        output = tmp_path / "report.csv"
+        result = self._renderer().render_csv(self._sample_data(), output)
+        assert result.is_absolute()
+        assert result == output.resolve()
+
+    def test_raises_output_path_error_on_missing_parent(self, tmp_path: Path) -> None:
+        output = tmp_path / "nonexistent" / "report.csv"
+        with pytest.raises(OutputPathError):
+            self._renderer().render_csv(self._sample_data(), output)
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`reveille generate --format csv` produces the ranked contributor table
as a UTF-8 CSV file with BOM encoding at the same path stem as the
`--output` argument. BOM ensures correct column rendering in Microsoft
Excel on Windows without requiring a manual import wizard configuration.

Combined with `--format json` and `--format both`, the output surface
now covers every common downstream consumption pattern.

## Changes

- `src/reveille/adapters/renderer.py`: `render_csv()` using stdlib `csv`
  only, `utf-8-sig` encoding.
- `src/reveille/config.py`: `OutputFormat` extended to include `"csv"`.
- `src/reveille/services/report.py`: CSV dispatch added.
- `src/reveille/cli.py`: `--format` help text updated.
- `tests/unit/adapters/test_renderer.py`: `TestRenderCsv` — 5 assertions
  covering header columns, BOM presence, row count, path, and missing parent.
- `tests/e2e/test_cli.py`: one assertion in `TestGenerateCommand`.
- `CHANGELOG.md`: Added entry.

## Test plan

`make ci` passes. 210 tests green.