### PR TITLE
docs/v0.6.0-pre-release: align documentation with v0.6.0 feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Reveille is designed for developers, engineering managers, and technical leads w
 - Per-contributor breakdowns covering commits, lines added and removed, and active day counts
 - A structured ranking table assigning each contributor a tier designation based on weighted activity metrics
 - Repository health indicators including bus factor, longest inactive streak, and consistency scores
+- Machine-readable output in JSON (ranked contributor statistics and repository metadata) and CSV (contributor table with BOM encoding for Excel compatibility) via `--format json`, `--format csv`, and `--format both`
 
 **Design constraints that are non-negotiable:**
 
@@ -42,6 +43,8 @@ Reveille is designed for developers, engineering managers, and technical leads w
 - The file must open in any modern browser with no internet connection. All JavaScript, CSS, and chart data are embedded inline.
 - No external CDN calls. No iframes. No cookies. No tracking.
 - The output aesthetic is formal and stakeholder-ready. No emojis. No casual language. Typography is clean and readable.
+
+**Security and observability:** The project is continuously scanned by GitHub CodeQL (static analysis on every pull request) and OpenSSF Scorecard (automated security health scoring on every push to main). Pipeline progress is reported via structured events carrying per-stage elapsed time, enabling CI log analysis of generation bottlenecks in large repositories.
 
 ---
 
@@ -157,6 +160,7 @@ Generates the HTML performance report for the target repository.
 | `--min-commits` | | `INT` | `1` | Exclude contributors with fewer than this many commits in the analysis window. |
 | `--title` | | `TEXT` | Repository name | Override the report title displayed in the HTML output. |
 | `--no-ranking` | | Flag | Off | Omit the contributor ranking table from the output. |
+| `--format` | | `TEXT` | `html` | Output format. Accepted values: `html`, `json`, `csv`, `both`. `json` and `csv` write files at the same path stem as `--output`. `both` produces HTML and JSON together. |
 | `--config` | `-c` | `PATH` | None | Path to a TOML configuration file. If omitted, `reveille.toml` in the current working directory is loaded automatically when present. Use this flag for non-standard file names or paths outside the repository root. CLI flags always take precedence over configuration file values. |
 
 ### `reveille init`
@@ -167,6 +171,7 @@ Scaffolds a fully annotated `reveille.toml` configuration file in the current di
 |---|---|---|---|---|
 | `--output` | `-o` | `PATH` | `./reveille.toml` | Destination path for the generated configuration file. |
 | `--force` | | Flag | Off | Overwrite an existing file at the target path without prompting. |
+| `--mailmap` | | Flag | Off | Generate an annotated `.mailmap` template at the repository root alongside `reveille.toml`. Documents two-field, three-field, and four-field format variants with real-world examples. An existing `.mailmap` is silently skipped. |
 
 ### `reveille version`
 
@@ -207,6 +212,10 @@ The generated HTML file is structured as a formal report with the following sect
 **Contribution Breakdown Charts** — Horizontal bar charts of commits and lines changed per contributor, and two donut charts showing each contributor's proportional share of total commits and total lines changed.
 
 **Repository Health Indicators** — Bus factor estimate (minimum number of contributors accounting for 50% of commits) and longest inactive streak within the analysis window.
+
+**JSON export** — When `--format json` or `--format both` is used, a structured JSON file is written at the same path stem as the HTML output. The payload contains repository metadata, ranked contributor statistics with all scoring fields, and derived health metrics. Suitable for dashboards, data warehouses, and CI integrations without parsing HTML.
+
+**CSV export** — When `--format csv` is used, the ranked contributor table is written as a UTF-8 CSV file with BOM encoding. BOM ensures correct column rendering in Microsoft Excel on Windows without requiring a manual import wizard. Columns: rank, name, email, designation, tier, commits, lines added, lines deleted, net lines, active days, last commit date, composite score, percentile.
 
 All charts are rendered with Plotly and are fully interactive — hover states, zoom, pan, and legend toggling are available without any external dependencies.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -171,6 +171,24 @@ for the full schema.
 reveille generate --config ./reveille.toml
 ```
 
+### `--format`
+
+Controls the output format for `reveille generate`. Accepts four values.
+
+`html` is the default and produces the single self-contained HTML file at the path specified by `--output`.
+
+`json` writes a structured JSON file at the same path stem as `--output` with a `.json` extension. The payload contains repository metadata, ranked contributor statistics with all scoring fields, and derived health metrics. The raw commits list is excluded. Suitable for consumption by dashboards and data warehouses without parsing HTML.
+
+`csv` writes the ranked contributor table as a UTF-8 CSV file with BOM encoding at the same path stem as `--output` with a `.csv` extension. BOM ensures correct column rendering in Microsoft Excel on Windows without requiring a manual import wizard configuration.
+
+`both` produces both the HTML and JSON files in a single invocation.
+
+```bash
+reveille generate --format json
+reveille generate --format both --output /tmp/reports/q4.html
+reveille generate --format csv --output /tmp/reports/q4.html
+```
+
 ---
 
 ## The `reveille init` Command
@@ -212,6 +230,17 @@ file already exists, to prevent accidental data loss.
 reveille init --force
 ```
 
+### `--mailmap`
+
+Generates a fully annotated `.mailmap` template at the repository root alongside `reveille.toml`. The template documents the two-field form (name correction), three-field form (email alias to canonical identity), and four-field form (name and email alias, marked as unsupported by Reveille in this release), each with concrete examples covering employer domain changes, GitHub noreply addresses, and name corrections.
+
+`--force` applies to both generated files when `--mailmap` is set. If a `.mailmap` file already exists, it is silently skipped — `.mailmap` is a Git-native file and its presence is not treated as a conflict.
+
+```bash
+reveille init --mailmap
+reveille init --mailmap --force
+```
+
 ---
 
 ## TOML Configuration Reference
@@ -240,6 +269,10 @@ since = "2024-10-01"
 
 # Analysis window end date. Equivalent to --until.
 until = "2024-12-31"
+
+# Output format. Equivalent to --format.
+# Accepted values: html (default), json, csv, both.
+# format = "html"
 
 
 [filters]
@@ -487,6 +520,32 @@ weights = { commits = 0.15, lines = 0.15, consistency = 0.40, recency = 0.30 }
 
 All four weights must sum to exactly 1.0. Reveille validates this at
 startup and exits with an error if the constraint is violated.
+
+### Exporting Machine-Readable Output for Downstream Integration
+
+`--format json` produces a structured JSON file at the same path stem as the HTML output. The payload contains repository metadata, ranked contributor statistics, and derived health metrics — suitable for dashboards, data warehouses, and Jira integrations without parsing HTML.
+
+```bash
+reveille generate --format json --output /tmp/reports/q4.html
+```
+
+To produce both the interactive report and the machine-readable payload in a single invocation:
+
+```bash
+reveille generate --format both --output /tmp/reports/q4.html
+```
+
+The JSON file is written to `/tmp/reports/q4.json`.
+
+### Exporting the Contributor Table to a Spreadsheet
+
+`--format csv` produces the ranked contributor table as a UTF-8 CSV file with BOM encoding, for direct import into Microsoft Excel, Google Sheets, or any spreadsheet application.
+
+```bash
+reveille generate --format csv --output /tmp/reports/q4.html
+```
+
+The CSV file is written to `/tmp/reports/q4.csv`.
 
 ### Embedding in Confluence
 

--- a/src/reveille/init.py
+++ b/src/reveille/init.py
@@ -47,6 +47,16 @@ _DEFAULT_CONFIG_TEMPLATE: str = """\
 # Defaults to today.
 # until = "2024-12-31"
 
+# Output format for the generated report.
+# Accepted values:
+#   html  -- A single self-contained HTML file (default).
+#   json  -- A structured JSON file containing ranked contributor statistics
+#            and repository metadata, suitable for downstream tooling.
+#   csv   -- The ranked contributor table as a UTF-8 CSV file with BOM
+#            encoding for direct import into Microsoft Excel.
+#   both  -- HTML and JSON files in a single invocation.
+# format = "html"
+
 
 # ------------------------------------------------------------------------------
 # [filters] -- Contributor and commit filtering


### PR DESCRIPTION
## Summary

Documentation-only. Aligns README, User Guide, and the annotated
init config template with all features introduced in Sprint 2.

## Changes

- `README.md`: `--format` in generate flag table, `--mailmap` in init
  flag table, JSON and CSV entries in Output Description, security and
  observability context in Overview.
- `docs/USER_GUIDE.md`: `--format` section in CLI Flags in Depth,
  `--mailmap` section under reveille init, `format` key in TOML
  Configuration Reference, two new practical patterns for JSON and CSV
  export workflows.
- `src/reveille/init.py`: `format` key added to the annotated
  `[report]` section of the default config template.

## Test plan

Documentation-only. CI lint and typecheck pass.