### PR TITLE
chore/release-v0.6.0: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [0.6.0] — 2026-05-29
+
 ### Added
 
 - `reveille init --mailmap` generates an annotated `.mailmap` template at the
@@ -371,7 +375,8 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.6.0
 [0.5.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.5.1
 [0.5.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.5.0
 [0.4.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.4.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the current stable release receives security fixes.
 
 | Version | Supported |
 |---------|-----------|
-| 0.5.x   | ✓         |
-| < 0.5.0 | ✗         |
+| 0.6.x   | ✓         |
+| < 0.6.0 | ✗         |
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.5.1"
+version = "0.6.0"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Varaprasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "MIT"

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -4,7 +4,7 @@ A CLI tool that generates self-contained HTML performance reports
 from local Git repositories.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 __author__ = "Varaprasad Chilakanti"
 __email__ = "varaprasadchilakanti@gmail.com"
 __licence__ = "MIT"


### PR DESCRIPTION
## Summary

v0.6.0 release. Promotes all [Unreleased] entries from Sprint 2.

## What ships in v0.6.0

- reveille init --mailmap generates an annotated .mailmap template
- Output path validation hardened against traversal sequences
- Contributor names sanitised before Plotly trace embedding
- ProgressEvent dataclass for typed pipeline observability
- --format json and --format both for machine-readable output
- --format csv for Excel-compatible ranked contributor table
- CodeQL and OpenSSF Scorecard security workflows