### PR TITLE
fix/readme-post-v0.6.0: pre-release readme cleanup and remove both format option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,11 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   spinner now displays per-stage elapsed time on completion lines. The service
   layer remains terminal-agnostic.
 - `--format` flag added to `reveille generate`. Accepted values are `html`
-  (default, existing behaviour), `json`, and `both`. `--format json` produces
-  a structured JSON file at the same path stem as the HTML output. `--format
-  both` produces both in a single invocation. The JSON payload contains
-  repository metadata, ranked contributor statistics with all scoring fields,
-  and derived health metrics. The raw commits list is excluded. Dates are
-  serialised as ISO 8601 strings.
+  (default, existing behaviour), `json`, and `csv`. `--format json` produces
+  a structured JSON file at the same path stem as the HTML output. The JSON
+  payload contains repository metadata, ranked contributor statistics with all
+  scoring fields, and derived health metrics. The raw commits list is excluded.
+  Dates are serialised as ISO 8601 strings.
 - `--format csv` added as an accepted output format, producing the ranked
   contributor table as a UTF-8 CSV file with BOM encoding. BOM ensures correct
   column rendering in Microsoft Excel on Windows without requiring a manual

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Reveille is designed for developers, engineering managers, and technical leads w
 - Per-contributor breakdowns covering commits, lines added and removed, and active day counts
 - A structured ranking table assigning each contributor a tier designation based on weighted activity metrics
 - Repository health indicators including bus factor, longest inactive streak, and consistency scores
-- Machine-readable output in JSON (ranked contributor statistics and repository metadata) and CSV (contributor table with BOM encoding for Excel compatibility) via `--format json`, `--format csv`, and `--format both`
+- Machine-readable output in JSON (ranked contributor statistics and repository metadata) and CSV (contributor table with BOM encoding for Excel compatibility) via `--format json`, `--format csv`
 
 **Design constraints that are non-negotiable:**
 
@@ -160,7 +160,7 @@ Generates the HTML performance report for the target repository.
 | `--min-commits` | | `INT` | `1` | Exclude contributors with fewer than this many commits in the analysis window. |
 | `--title` | | `TEXT` | Repository name | Override the report title displayed in the HTML output. |
 | `--no-ranking` | | Flag | Off | Omit the contributor ranking table from the output. |
-| `--format` | | `TEXT` | `html` | Output format. Accepted values: `html`, `json`, `csv`, `both`. `json` and `csv` write files at the same path stem as `--output`. `both` produces HTML and JSON together. |
+| `--format` | | `TEXT` | `html` | Output format. Accepted values: `html`, `json`, `csv`. `json` and `csv` write files at the same path stem as `--output`. |
 | `--config` | `-c` | `PATH` | None | Path to a TOML configuration file. If omitted, `reveille.toml` in the current working directory is loaded automatically when present. Use this flag for non-standard file names or paths outside the repository root. CLI flags always take precedence over configuration file values. |
 
 ### `reveille init`
@@ -213,7 +213,7 @@ The generated HTML file is structured as a formal report with the following sect
 
 **Repository Health Indicators** — Bus factor estimate (minimum number of contributors accounting for 50% of commits) and longest inactive streak within the analysis window.
 
-**JSON export** — When `--format json` or `--format both` is used, a structured JSON file is written at the same path stem as the HTML output. The payload contains repository metadata, ranked contributor statistics with all scoring fields, and derived health metrics. Suitable for dashboards, data warehouses, and CI integrations without parsing HTML.
+**JSON export** — When `--format json` is used, a structured JSON file is written at the same path stem as the HTML output. The payload contains repository metadata, ranked contributor statistics with all scoring fields, and derived health metrics. Suitable for dashboards, data warehouses, and CI integrations without parsing HTML.
 
 **CSV export** — When `--format csv` is used, the ranked contributor table is written as a UTF-8 CSV file with BOM encoding. BOM ensures correct column rendering in Microsoft Excel on Windows without requiring a manual import wizard. Columns: rank, name, email, designation, tier, commits, lines added, lines deleted, net lines, active days, last commit date, composite score, percentile.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reveille
 
-**A CLI tool that generates self-contained HTML performance reports from local Git repositories.**
+**A CLI tool that generates performance reports from local Git repositories — as self-contained HTML, structured JSON, and CSV.**
 
 Reveille reads your repository's Git history and produces a single portable `.html` file containing interactive visualisations of contributor activity, commit trends, code volume, and repository health — with no server, no external API calls, and no configuration beyond the command itself. Open the output in any browser, share it over email, or drop it into a Confluence page without modification.
 
@@ -267,6 +267,7 @@ output = "./reports/q4-2024.html"
 branch = "main"
 since = "2024-10-01"
 until = "2024-12-31"
+format = "html"
 
 [filters]
 min_commits = 2

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -181,11 +181,8 @@ Controls the output format for `reveille generate`. Accepts four values.
 
 `csv` writes the ranked contributor table as a UTF-8 CSV file with BOM encoding at the same path stem as `--output` with a `.csv` extension. BOM ensures correct column rendering in Microsoft Excel on Windows without requiring a manual import wizard configuration.
 
-`both` produces both the HTML and JSON files in a single invocation.
-
 ```bash
-reveille generate --format json
-reveille generate --format both --output /tmp/reports/q4.html
+reveille generate --format json --output /tmp/reports/q4.html
 reveille generate --format csv --output /tmp/reports/q4.html
 ```
 
@@ -271,7 +268,7 @@ since = "2024-10-01"
 until = "2024-12-31"
 
 # Output format. Equivalent to --format.
-# Accepted values: html (default), json, csv, both.
+# Accepted values: html (default), json, csv.
 # format = "html"
 
 
@@ -527,12 +524,6 @@ startup and exits with an error if the constraint is violated.
 
 ```bash
 reveille generate --format json --output /tmp/reports/q4.html
-```
-
-To produce both the interactive report and the machine-readable payload in a single invocation:
-
-```bash
-reveille generate --format both --output /tmp/reports/q4.html
 ```
 
 The JSON file is written to `/tmp/reports/q4.json`.

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -258,7 +258,7 @@ def _merge_cli_flags(
         exclude_author: List of authors to exclude, or None.
         min_commits: Minimum commit threshold, or None if not provided.
         no_ranking: Whether ranking is disabled.
-        output_format: Output format string. Accepted values: html, json, both.
+        output_format: Output format string. Accepted values: html, json, csv.
 
     Returns:
         A merged ReportConfigKwargs ready for ReportConfig construction.
@@ -333,7 +333,7 @@ def generate(
         str,
         typer.Option(
             "--format",
-            help="Output format. Accepted values: html, json, both, csv.",
+            help="Output format. Accepted values: html, json, csv.",
         ),
     ] = "html",
     config: Annotated[

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from reveille.exceptions import ConfigurationError
 
-OutputFormat = Literal["html", "json", "both", "csv"]
+OutputFormat = Literal["html", "json", "csv"]
 
 
 class RankingWeights(BaseModel):

--- a/src/reveille/init.py
+++ b/src/reveille/init.py
@@ -54,7 +54,6 @@ _DEFAULT_CONFIG_TEMPLATE: str = """\
 #            and repository metadata, suitable for downstream tooling.
 #   csv   -- The ranked contributor table as a UTF-8 CSV file with BOM
 #            encoding for direct import into Microsoft Excel.
-#   both  -- HTML and JSON files in a single invocation.
 # format = "html"
 
 

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -131,9 +131,9 @@ def generate_report(
 
     renderer = Renderer()
     paths: list[Path] = []
-    if config.output_format in ("html", "both"):
+    if config.output_format == "html":
         paths.append(renderer.render(report_data, config.output_path))
-    if config.output_format in ("json", "both"):
+    if config.output_format == "json":
         paths.append(renderer.render_json(report_data, config.output_path.with_suffix(".json")))
     if config.output_format == "csv":
         paths.append(renderer.render_csv(report_data, config.output_path.with_suffix(".csv")))

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -594,30 +594,6 @@ class TestGenerateCommand:
         assert result.exit_code == 0
         assert (base / "report.json").exists()
 
-    def test_format_both_produces_html_and_json_files(
-        self,
-        e2e_repo: Path,
-        tmp_path_factory: pytest.TempPathFactory,
-    ) -> None:
-        """--format both writes both .html and .json files in a single invocation."""
-        base = tmp_path_factory.mktemp("format_both")
-        output = base / "report.html"
-        result = runner.invoke(
-            app,
-            [
-                "generate",
-                "--repo",
-                str(e2e_repo),
-                "--output",
-                str(output),
-                "--format",
-                "both",
-            ],
-        )
-        assert result.exit_code == 0
-        assert output.exists()
-        assert (base / "report.json").exists()
-
     def test_format_csv_produces_csv_file(
         self,
         e2e_repo: Path,


### PR DESCRIPTION
## Summary

Two cleanup changes before tagging v0.6.0.

1. README tagline updated to reflect the full output surface (HTML,
   JSON, CSV), and the `format` key added to the inline TOML example
   in the Configuration section.

2. `both` removed from `OutputFormat`. The value was introduced in
   `feat/json-export` but never published. With the incremental cache
   landing in Sprint 3, re-running `reveille generate` with a different
   `--format` value against an already-processed repository will be
   near-instantaneous, making a combined flag unnecessary. Three clean
   values remain: `html`, `json`, `csv`.

## Changes

- `README.md`: tagline and TOML example updated.
- `src/reveille/config.py`: `OutputFormat` trimmed to `Literal["html", "json", "csv"]`.
- `src/reveille/services/report.py`: dispatch conditions simplified to equality checks.
- `src/reveille/cli.py`: `--format` help text updated.
- `tests/e2e/test_cli.py`: `test_format_both_produces_html_and_json_files` removed.
- `CHANGELOG.md`: json-export Added entry updated to remove `both` references.

## Test plan

`make ci` passes. 209 tests green.