### PR TITLE
fix/noreply-identity: fold GitHub's two private-commit address forms into one identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- GitHub's two private-commit address forms are now folded together. An account
+  whose history spans GitHub's 2017 change appears under both
+  `username@users.noreply.github.com` and
+  `12345678+username@users.noreply.github.com`, and aggregated as two separate
+  contributors. The numeric account ID is stripped, so both forms resolve to one
+  identity, and the ID no longer leaks into report output. A `.mailmap` entry is
+  an explicit statement of intent and always takes precedence over this
+  automatic folding; entries written against either form are honoured, the
+  address as recorded on the commit taking priority. `--exclude-author` matches
+  the raw address as well as the resolved one, so a value copied from `git log`
+  continues to work.
+- Note the scope of this fix: it merges an account's *noreply* addresses with
+  each other. It cannot merge a noreply address with a personal address, since
+  nothing in the commit data establishes that link. A contributor who commits
+  both locally and through the GitHub web interface still needs a `.mailmap`
+  entry to appear once; `reveille init --mailmap` generates an annotated
+  template covering exactly this case.
+
 ### Changed
 
 - Commit history is now read in a single `git log --numstat` subprocess,

--- a/src/reveille/adapters/git_reader.py
+++ b/src/reveille/adapters/git_reader.py
@@ -6,7 +6,9 @@ receive domain objects and have no knowledge of the underlying library.
 
 Identity resolution uses author email as the canonical contributor key.
 Author name is taken from the contributor's most recent commit, which
-handles name changes over a repository's lifetime gracefully.
+handles name changes over a repository's lifetime gracefully. A `.mailmap`
+is applied first where present, then GitHub's two private-commit address
+forms are folded together so one account does not split across both.
 
 Merge commits are excluded from all analysis. They inflate line counts
 and commit volumes without reflecting individual contributor activity.
@@ -38,6 +40,67 @@ _RECORD_SEP = "\x1e"
 _FIELD_SEP = "\x1f"
 
 _LOG_FORMAT = f"--format={_RECORD_SEP}%H{_FIELD_SEP}%an{_FIELD_SEP}%ae{_FIELD_SEP}%ct"
+
+# GitHub's prefixed private-commit address: 12345678+username@users.noreply.github.com.
+# The username is captured; the numeric account ID is discarded.
+_GITHUB_NOREPLY_RE = re.compile(
+    r"^\d+\+(?P<username>[^@]+)@users\.noreply\.github\.com$",
+    re.IGNORECASE,
+)
+
+
+def _normalise_github_noreply(email: str) -> str:
+    """Strip the numeric account prefix from a GitHub noreply address.
+
+    GitHub issues two forms of private commit address for the same account:
+    the legacy `username@users.noreply.github.com` and, since 2017, the
+    prefixed `12345678+username@users.noreply.github.com`. A contributor
+    whose account spans the change appears under both, and the numeric ID
+    also leaks into report output for no reader benefit.
+
+    Args:
+        email: An author email address, in any form.
+
+    Returns:
+        The address with the numeric prefix removed if it is a prefixed
+        GitHub noreply address, otherwise the address unchanged.
+    """
+    match = _GITHUB_NOREPLY_RE.match(email)
+    if match is None:
+        return email
+    return f"{match.group('username')}@users.noreply.github.com"
+
+
+def _resolve_identity(
+    name: str,
+    email: str,
+    mailmap: dict[str, tuple[str, str]],
+) -> tuple[str, str]:
+    """Resolve a raw author identity to its canonical name and email.
+
+    A `.mailmap` entry is an explicit statement of intent by the repository
+    owner and always wins. Entries written against either GitHub noreply
+    form are honoured, the raw address taking precedence. An address that
+    `.mailmap` does not cover falls back to noreply normalisation.
+
+    Args:
+        name: Author name as recorded on the commit.
+        email: Author email as recorded on the commit.
+        mailmap: Alias mapping from `_read_mailmap`, keyed on lowercased
+            alias email.
+
+    Returns:
+        A tuple of (canonical_name, canonical_email).
+    """
+    normalised = _normalise_github_noreply(email)
+
+    mapped = mailmap.get(email.lower())
+    if mapped is None and normalised != email:
+        mapped = mailmap.get(normalised.lower())
+    if mapped is not None:
+        return mapped
+
+    return name, normalised
 
 
 def _sum_numstat(block: str) -> tuple[int, int]:
@@ -112,7 +175,8 @@ class GitReader:
         including per-commit line counts.
 
         Merge commits are unconditionally excluded. Author filtering
-        matches against both name and email, case-insensitively.
+        matches against name, resolved email, and the raw email as
+        recorded on the commit, case-insensitively.
 
         The until date is inclusive: commits on that calendar day are
         included in the result.
@@ -171,13 +235,17 @@ class GitReader:
             if len(fields) != 4:
                 continue
 
-            sha, author_name, author_email, committed_at = fields
+            sha, raw_name, raw_email, committed_at = fields
 
-            email_key = author_email.lower()
-            if email_key in mailmap:
-                author_name, author_email = mailmap[email_key]
+            author_name, author_email = _resolve_identity(raw_name, raw_email, mailmap)
 
-            if author_name.lower() in exclude_set or author_email.lower() in exclude_set:
+            # The raw address is matched too so that an --exclude-author
+            # value copied from `git log` still works after normalisation.
+            if (
+                author_name.lower() in exclude_set
+                or author_email.lower() in exclude_set
+                or raw_email.lower() in exclude_set
+            ):
                 continue
 
             lines_added, lines_deleted = _sum_numstat(numstat_block)

--- a/tests/integration/test_git_reader.py
+++ b/tests/integration/test_git_reader.py
@@ -585,3 +585,125 @@ class TestLineCounts:
         root = next(reversed(commits))
         assert root.lines_added == 2
         assert root.lines_deleted == 0
+
+
+# ------------------------------------------------------------------
+# GitHub noreply identity tests
+# ------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def noreply_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a repository where one account uses both GitHub noreply forms.
+
+    Commit history (chronological):
+        Alice  140685918+alice@users.noreply.github.com   prefixed form
+        Alice  alice@users.noreply.github.com             legacy form
+        Bob    bob@example.com                            ordinary address
+
+    Alice is one GitHub account whose commits span the 2017 address change.
+    Without normalisation she aggregates as two separate contributors.
+    """
+    repo_path = tmp_path_factory.mktemp("noreply_repo")
+
+    def run(args: list[str], env_override: dict[str, str] | None = None) -> None:
+        env = {**os.environ, **(env_override or {})}
+        subprocess.run(args, cwd=repo_path, check=True, capture_output=True, env=env)
+
+    def identity(name: str, email: str) -> dict[str, str]:
+        return {
+            "GIT_AUTHOR_NAME": name,
+            "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name,
+            "GIT_COMMITTER_EMAIL": email,
+        }
+
+    run(["git", "init", "-b", "main"])
+    run(["git", "config", "user.email", "alice@example.com"])
+    run(["git", "config", "user.name", "Alice"])
+
+    (repo_path / "a.py").write_text("x = 1\n")
+    run(["git", "add", "."])
+    run(
+        ["git", "commit", "-m", "feat: prefixed form"],
+        env_override=identity("Alice", "140685918+alice@users.noreply.github.com"),
+    )
+
+    (repo_path / "b.py").write_text("y = 2\n")
+    run(["git", "add", "."])
+    run(
+        ["git", "commit", "-m", "feat: legacy form"],
+        env_override=identity("Alice", "alice@users.noreply.github.com"),
+    )
+
+    (repo_path / "c.py").write_text("z = 3\n")
+    run(["git", "add", "."])
+    run(
+        ["git", "commit", "-m", "feat: ordinary address"],
+        env_override=identity("Bob", "bob@example.com"),
+    )
+
+    return repo_path
+
+
+@pytest.mark.integration
+class TestGithubNoreplyIdentity:
+    """Tests for GitHub noreply address folding in read_commits."""
+
+    def test_github_noreply_prefix_stripped(self, noreply_repo: Path) -> None:
+        reader = GitReader(noreply_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        emails = {c.author_email for c in commits}
+        assert "140685918+alice@users.noreply.github.com" not in emails
+        assert "alice@users.noreply.github.com" in emails
+
+    def test_non_noreply_email_unaffected(self, noreply_repo: Path) -> None:
+        reader = GitReader(noreply_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        assert "bob@example.com" in {c.author_email for c in commits}
+
+    def test_both_noreply_forms_aggregate_as_one_contributor(self, noreply_repo: Path) -> None:
+        """The headline fix: one account must not appear as two contributors."""
+        reader = GitReader(noreply_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        stats = reader.aggregate_contributor_stats(commits=commits, min_commits=1)
+        assert len(stats) == 2
+        alice = next(s for s in stats if s.email == "alice@users.noreply.github.com")
+        assert alice.commit_count == 2
+
+    def test_exclusion_by_raw_prefixed_address_still_works(self, noreply_repo: Path) -> None:
+        """An --exclude-author copied from `git log` matches the raw form."""
+        reader = GitReader(noreply_repo)
+        commits = reader.read_commits(
+            branch=None,
+            since=None,
+            until=None,
+            exclude_authors=["140685918+alice@users.noreply.github.com"],
+        )
+        assert len(commits) == 2
+
+    def test_exclusion_by_normalised_address_matches_both_forms(self, noreply_repo: Path) -> None:
+        """An --exclude-author copied from report output removes the account."""
+        reader = GitReader(noreply_repo)
+        commits = reader.read_commits(
+            branch=None,
+            since=None,
+            until=None,
+            exclude_authors=["alice@users.noreply.github.com"],
+        )
+        assert len(commits) == 1
+        assert commits[0].author_email == "bob@example.com"
+
+    def test_mailmap_entry_overrides_normalisation(self, noreply_repo: Path) -> None:
+        """An explicit .mailmap statement wins over automatic folding."""
+        mailmap = noreply_repo / ".mailmap"
+        mailmap.write_text(
+            "Alice Real <alice@example.com> <140685918+alice@users.noreply.github.com>\n"
+        )
+        try:
+            reader = GitReader(noreply_repo)
+            commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+            emails = {c.author_email for c in commits}
+            assert "alice@example.com" in emails
+        finally:
+            mailmap.unlink()

--- a/tests/unit/adapters/test_git_reader.py
+++ b/tests/unit/adapters/test_git_reader.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 import pytest
 
-from reveille.adapters.git_reader import _sum_numstat
+from reveille.adapters.git_reader import (
+    _normalise_github_noreply,
+    _resolve_identity,
+    _sum_numstat,
+)
 
 
 @pytest.mark.unit
@@ -54,3 +58,110 @@ class TestSumNumstat:
         # git never emits these; isdigit() rejects them rather than
         # letting a malformed value subtract from the total.
         assert _sum_numstat("-4\t-2\tmodule_a.py") == (0, 0)
+
+
+@pytest.mark.unit
+class TestNormaliseGithubNoreply:
+    """Tests for _normalise_github_noreply, the GitHub address folder."""
+
+    def test_prefixed_address_loses_its_numeric_id(self) -> None:
+        assert (
+            _normalise_github_noreply("140685918+alice@users.noreply.github.com")
+            == "alice@users.noreply.github.com"
+        )
+
+    def test_legacy_address_is_unchanged(self) -> None:
+        # Already canonical; normalising must be idempotent.
+        assert (
+            _normalise_github_noreply("alice@users.noreply.github.com")
+            == "alice@users.noreply.github.com"
+        )
+
+    def test_normalisation_is_idempotent(self) -> None:
+        once = _normalise_github_noreply("1+alice@users.noreply.github.com")
+        assert _normalise_github_noreply(once) == once
+
+    def test_ordinary_address_is_unchanged(self) -> None:
+        assert _normalise_github_noreply("alice@example.com") == "alice@example.com"
+
+    def test_bot_username_with_brackets_is_handled(self) -> None:
+        # dependabot commits under 49699333+dependabot[bot]@users.noreply.github.com
+        assert (
+            _normalise_github_noreply("49699333+dependabot[bot]@users.noreply.github.com")
+            == "dependabot[bot]@users.noreply.github.com"
+        )
+
+    def test_domain_match_is_case_insensitive(self) -> None:
+        assert (
+            _normalise_github_noreply("42+Alice@Users.NoReply.GitHub.Com")
+            == "Alice@users.noreply.github.com"
+        )
+
+    def test_other_noreply_domain_is_unchanged(self) -> None:
+        # Only GitHub's domain is folded; a lookalike must pass through.
+        address = "12345+alice@users.noreply.gitlab.com"
+        assert _normalise_github_noreply(address) == address
+
+    def test_prefix_without_digits_is_unchanged(self) -> None:
+        address = "team+alice@users.noreply.github.com"
+        assert _normalise_github_noreply(address) == address
+
+    def test_empty_string_is_unchanged(self) -> None:
+        assert _normalise_github_noreply("") == ""
+
+
+@pytest.mark.unit
+class TestResolveIdentity:
+    """Tests for _resolve_identity, mailmap and noreply resolution combined."""
+
+    def test_unmapped_ordinary_address_passes_through(self) -> None:
+        assert _resolve_identity("Alice", "alice@example.com", {}) == (
+            "Alice",
+            "alice@example.com",
+        )
+
+    def test_unmapped_noreply_address_is_normalised(self) -> None:
+        assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", {}) == (
+            "Alice",
+            "alice@users.noreply.github.com",
+        )
+
+    def test_mailmap_entry_on_raw_address_wins(self) -> None:
+        mailmap = {"99+alice@users.noreply.github.com": ("Alice Real", "alice@example.com")}
+        assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", mailmap) == (
+            "Alice Real",
+            "alice@example.com",
+        )
+
+    def test_mailmap_entry_on_normalised_address_also_matches(self) -> None:
+        # An entry written against the legacy form catches the prefixed form.
+        mailmap = {"alice@users.noreply.github.com": ("Alice Real", "alice@example.com")}
+        assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", mailmap) == (
+            "Alice Real",
+            "alice@example.com",
+        )
+
+    def test_raw_mailmap_entry_takes_precedence_over_normalised(self) -> None:
+        mailmap = {
+            "99+alice@users.noreply.github.com": ("Raw Match", "raw@example.com"),
+            "alice@users.noreply.github.com": ("Normalised Match", "norm@example.com"),
+        }
+        assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", mailmap) == (
+            "Raw Match",
+            "raw@example.com",
+        )
+
+    def test_mailmap_lookup_is_case_insensitive_on_the_raw_address(self) -> None:
+        mailmap = {"alice@example.com": ("Alice Real", "alice@example.com")}
+        assert _resolve_identity("Alice", "ALICE@example.com", mailmap) == (
+            "Alice Real",
+            "alice@example.com",
+        )
+
+    def test_mailmap_target_that_is_a_noreply_address_is_left_alone(self) -> None:
+        # The mailmap states intent explicitly; it is not second-guessed.
+        mailmap = {"alice@example.com": ("Alice", "7+alice@users.noreply.github.com")}
+        assert _resolve_identity("Alice", "alice@example.com", mailmap) == (
+            "Alice",
+            "7+alice@users.noreply.github.com",
+        )


### PR DESCRIPTION
### Summary
- Normalises GitHub noreply addresses by stripping numeric account IDs.
- Resolves identity with mailmap+noreply logic: mailmap always wins, raw takes priority.
- --exclude-author matches both raw and resolved addresses.
- Prevents leaked numeric IDs in contributor output.

### Verification
- Ruff clean, mypy strict, all 9 pre-commit hooks pass.
- 246 tests (+22), coverage 92.90% (git_reader 91.76%).
- Verified on repo: contributors fold correctly, numeric IDs removed.

### Notes
- Severity lower than initially quoted: merge-button commits already excluded.
- Duplicate contributor entries (personal vs. noreply) require .mailmap; code cannot merge them safely.
- Suggested follow-up: detect likely-split identities and print a hint pointing at `reveille init --mailmap`.
