### PR TITLE
feat/mailmap-four-field: implement the full gitmailmap specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,29 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Complete `.mailmap` support. All four forms documented in gitmailmap(5) are
+  now parsed, where previously two were. The four-field form
+  (`Proper Name <proper@email> Commit Name <commit@email>`) matches on commit
+  name and email together, which is the only form that can disentangle several
+  people who committed under one shared address — a default `git config` left
+  in place on a build machine, for example. Where more than one entry could
+  apply, the most specific wins, matching Git. A comment now runs to the end of
+  the line rather than requiring its own line, and names and addresses are
+  matched case-insensitively, both as Git does. Verified against
+  `git log --use-mailmap`: identical resolved identities across every form.
+- `reveille init --mailmap` documents the two previously undocumented forms
+  with worked examples, and no longer states that the four-field form is
+  unsupported.
+
 ### Fixed
+
+- The email-only `.mailmap` form (`<proper@email> <commit@email>`) was parsed
+  as a name-only entry, taking the literal text `<proper@email>` — angle
+  brackets included — as the contributor's display name and leaving the address
+  unmapped. It now replaces the address and preserves each commit's own name,
+  which is what Git does.
 
 - GitHub's two private-commit address forms are now folded together. An account
   whose history spans GitHub's 2017 change appears under both

--- a/src/reveille/adapters/git_reader.py
+++ b/src/reveille/adapters/git_reader.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import datetime
 import re
 from collections import defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
@@ -48,6 +49,15 @@ _GITHUB_NOREPLY_RE = re.compile(
     re.IGNORECASE,
 )
 
+# The four .mailmap forms documented in gitmailmap(5). Ordered most
+# specific first: a four-field line also satisfies no other pattern, but
+# an email-only line would otherwise be captured by the name-only form
+# with the literal "<proper@email>" text taken as a display name.
+_MAILMAP_FOUR_FIELD = re.compile(r"^(.+?)\s+<([^>]+)>\s+(.+?)\s+<([^>]+)>$")
+_MAILMAP_THREE_FIELD = re.compile(r"^(.+?)\s+<([^>]+)>\s+<([^>]+)>$")
+_MAILMAP_EMAIL_ONLY = re.compile(r"^<([^>]+)>\s+<([^>]+)>$")
+_MAILMAP_NAME_ONLY = re.compile(r"^(.+?)\s+<([^>]+)>$")
+
 
 def _normalise_github_noreply(email: str) -> str:
     """Strip the numeric account prefix from a GitHub noreply address.
@@ -71,11 +81,47 @@ def _normalise_github_noreply(email: str) -> str:
     return f"{match.group('username')}@users.noreply.github.com"
 
 
-def _resolve_identity(
-    name: str,
-    email: str,
-    mailmap: dict[str, tuple[str, str]],
-) -> tuple[str, str]:
+@dataclass(frozen=True)
+class _Mailmap:
+    """Parsed `.mailmap` lookup tables.
+
+    Git matches a commit against the most specific entry available, so
+    the two forms that carry a commit name are kept apart from those
+    keyed on email alone.
+
+    Attributes:
+        by_email: Keyed on lowercased commit email. Covers the name-only,
+            email-only, and three-field forms. A `None` canonical name
+            means the entry replaces the email only and the commit's own
+            name is kept, which is the email-only form's semantics.
+        by_name_and_email: Keyed on (lowercased commit name, lowercased
+            commit email). Covers the four-field form, which matches only
+            when both fields agree.
+    """
+
+    by_email: dict[str, tuple[str | None, str]] = field(default_factory=dict)
+    by_name_and_email: dict[tuple[str, str], tuple[str | None, str]] = field(default_factory=dict)
+
+    def lookup(self, name: str, email: str) -> tuple[str | None, str] | None:
+        """Find the most specific entry matching a commit identity.
+
+        Both names and emails are matched case-insensitively, as Git does.
+
+        Args:
+            name: Author name as recorded on the commit.
+            email: Author email as recorded on the commit.
+
+        Returns:
+            The matching (canonical_name, canonical_email) entry, or None
+            when no entry applies.
+        """
+        entry = self.by_name_and_email.get((name.lower(), email.lower()))
+        if entry is not None:
+            return entry
+        return self.by_email.get(email.lower())
+
+
+def _resolve_identity(name: str, email: str, mailmap: _Mailmap) -> tuple[str, str]:
     """Resolve a raw author identity to its canonical name and email.
 
     A `.mailmap` entry is an explicit statement of intent by the repository
@@ -86,19 +132,21 @@ def _resolve_identity(
     Args:
         name: Author name as recorded on the commit.
         email: Author email as recorded on the commit.
-        mailmap: Alias mapping from `_read_mailmap`, keyed on lowercased
-            alias email.
+        mailmap: Parsed mappings from `_read_mailmap`.
 
     Returns:
         A tuple of (canonical_name, canonical_email).
     """
     normalised = _normalise_github_noreply(email)
 
-    mapped = mailmap.get(email.lower())
+    mapped = mailmap.lookup(name, email)
     if mapped is None and normalised != email:
-        mapped = mailmap.get(normalised.lower())
+        mapped = mailmap.lookup(name, normalised)
+
     if mapped is not None:
-        return mapped
+        canonical_name, canonical_email = mapped
+        # The email-only form replaces the address but keeps the name.
+        return (name if canonical_name is None else canonical_name), canonical_email
 
     return name, normalised
 
@@ -385,48 +433,62 @@ class GitReader:
         except IndexError:
             return str(self._repo.remotes[0].url)
 
-    def _read_mailmap(self) -> dict[str, tuple[str, str]]:
+    def _read_mailmap(self) -> _Mailmap:
         """Read and parse the .mailmap file from the repository root.
 
-        Supports the two-field form ("Proper Name <commit@email.xx>") and
-        the three-field form ("Proper Name <canonical@email.xx> <commit@email.xx>").
-        The two-field form updates the author name only; the email is unchanged.
-        The three-field form updates both the author name and the email.
-        # TODO: four-field form — "Proper Name <proper@email.xx> Other Name <commit@email.xx>"
+        All four forms documented in gitmailmap(5) are supported. See
+        `_Mailmap` for how the parsed entries are looked up. A comment
+        (`#`) runs to end of line, and blank lines are ignored, matching
+        Git. Malformed lines are skipped silently: a `.mailmap` is
+        frequently hand-edited, and refusing to produce a report over one
+        bad line would be a worse failure than ignoring it.
 
         Returns:
-            A dict mapping lowercased alias email to a
-            (canonical_name, lowercased_canonical_email) tuple. Returns
-            an empty dict if the .mailmap file is absent or unreadable.
+            The parsed lookup tables. Empty if the file is absent or
+            unreadable.
         """
         mailmap_path = self._repo_path / ".mailmap"
         if not mailmap_path.exists():
-            return {}
+            return _Mailmap()
 
         try:
             lines = mailmap_path.read_text(encoding="utf-8").splitlines()
         except OSError:
-            return {}
+            return _Mailmap()
 
-        _three_field = re.compile(r"^(.+?)\s+<([^>]+)>\s+<([^>]+)>\s*$")
-        _two_field = re.compile(r"^(.+?)\s+<([^>]+)>\s*$")
-
-        mapping: dict[str, tuple[str, str]] = {}
+        mailmap = _Mailmap()
         for line in lines:
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
+            # A comment runs to end of line, not just whole-line comments.
+            stripped = line.split("#", 1)[0].strip()
+            if not stripped:
                 continue
-            m3 = _three_field.match(stripped)
-            if m3:
-                canonical_name = m3.group(1).strip()
-                canonical_email = m3.group(2).lower()
-                alias_email = m3.group(3).lower()
-                mapping[alias_email] = (canonical_name, canonical_email)
-                continue
-            m2 = _two_field.match(stripped)
-            if m2:
-                canonical_name = m2.group(1).strip()
-                email = m2.group(2).lower()
-                mapping[email] = (canonical_name, email)
 
-        return mapping
+            m4 = _MAILMAP_FOUR_FIELD.match(stripped)
+            if m4:
+                mailmap.by_name_and_email[(m4.group(3).strip().lower(), m4.group(4).lower())] = (
+                    m4.group(1).strip(),
+                    m4.group(2).lower(),
+                )
+                continue
+
+            m3 = _MAILMAP_THREE_FIELD.match(stripped)
+            if m3:
+                mailmap.by_email[m3.group(3).lower()] = (
+                    m3.group(1).strip(),
+                    m3.group(2).lower(),
+                )
+                continue
+
+            m2 = _MAILMAP_EMAIL_ONLY.match(stripped)
+            if m2:
+                # Only the email is replaced; the commit's name is kept,
+                # which None signals to _resolve_identity.
+                mailmap.by_email[m2.group(2).lower()] = (None, m2.group(1).lower())
+                continue
+
+            m1 = _MAILMAP_NAME_ONLY.match(stripped)
+            if m1:
+                email = m1.group(2).lower()
+                mailmap.by_email[email] = (m1.group(1).strip(), email)
+
+        return mailmap

--- a/src/reveille/init.py
+++ b/src/reveille/init.py
@@ -131,6 +131,21 @@ _DEFAULT_MAILMAP_TEMPLATE: str = """\
 #
 #
 # ------------------------------------------------------------------------------
+# EMAIL-ONLY FORM -- address correction, name untouched
+#
+#   <canonical@email.example> <alias@email.example>
+#
+# Maps commits from the alias address to the canonical address while
+# leaving each commit's own display name as recorded. Use this when the
+# address changed but the name is already correct, or varies legitimately.
+#
+# Example:
+#
+#   Address change with no name change:
+#   <helen@newcorp.com> <helen@oldcorp.com>
+#
+#
+# ------------------------------------------------------------------------------
 # THREE-FIELD FORM -- email alias to canonical identity
 #
 #   Canonical Name <canonical@email.example> <alias@email.example>
@@ -158,17 +173,29 @@ _DEFAULT_MAILMAP_TEMPLATE: str = """\
 #   Canonical Name <canonical@email.example> Old Name <old@email.example>
 #
 # Maps commits made under a specific combination of old name and old email
-# to the canonical identity. Required when both the name and email changed
-# simultaneously.
+# to the canonical identity. The entry applies only when both the name and
+# the address match, so it is the form to use when several people have
+# committed under one shared address -- a default `git config` left in
+# place on a build machine, for example. The other forms key on the
+# address alone and would rewrite every contributor using it.
 #
-# NOTE: The four-field form is recognised by Git but is not yet supported
-# by Reveille. Commits matching the old name and email will not be merged
-# into the canonical identity until support is added. Use the three-field
-# form as a partial workaround when the email address is unique. Full
-# support is planned for a future release.
+# Examples:
 #
-# Example:
+#   Both name and address changed at once:
 #   Dan Brown <dan@newcorp.com> Daniel Brown <daniel@oldcorp.com>
+#
+#   Disentangling two people who shared one address:
+#   Dan Brown <dan@corp.com> Dan <build@ci.corp.com>
+#   Erica Stone <erica@corp.com> Erica <build@ci.corp.com>
+#
+#
+# ------------------------------------------------------------------------------
+# MATCHING NOTES
+#
+# Names and addresses are matched case-insensitively. Where more than one
+# entry could apply, the most specific wins: a four-field entry matching
+# both name and address takes precedence over one keyed on address alone.
+# A `#` begins a comment that runs to the end of the line.
 #
 """
 

--- a/tests/integration/test_git_reader.py
+++ b/tests/integration/test_git_reader.py
@@ -707,3 +707,128 @@ class TestGithubNoreplyIdentity:
             assert "alice@example.com" in emails
         finally:
             mailmap.unlink()
+
+
+# ------------------------------------------------------------------
+# Full .mailmap specification tests
+# ------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def four_field_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a repository exercising all four gitmailmap(5) forms.
+
+    Commit history (chronological):
+        Daniel Brown <daniel@oldcorp.com>   four-field target
+        Erica Stone  <daniel@oldcorp.com>   same address, different name
+        Frank Lee    <frank-old@example.com>  email-only target
+        Grace Kim    <grace@example.com>    name-only target
+
+    Erica shares Daniel's old address, which is what the four-field form
+    exists to disambiguate: only Daniel's commits may be rewritten.
+    """
+    repo_path = tmp_path_factory.mktemp("four_field_repo")
+
+    def run(args: list[str], env_override: dict[str, str] | None = None) -> None:
+        env = {**os.environ, **(env_override or {})}
+        subprocess.run(args, cwd=repo_path, check=True, capture_output=True, env=env)
+
+    def identity(name: str, email: str) -> dict[str, str]:
+        return {
+            "GIT_AUTHOR_NAME": name,
+            "GIT_AUTHOR_EMAIL": email,
+            "GIT_COMMITTER_NAME": name,
+            "GIT_COMMITTER_EMAIL": email,
+        }
+
+    run(["git", "init", "-b", "main"])
+    run(["git", "config", "user.email", "seed@example.com"])
+    run(["git", "config", "user.name", "Seed"])
+
+    authors = [
+        ("Daniel Brown", "daniel@oldcorp.com"),
+        ("Erica Stone", "daniel@oldcorp.com"),
+        ("Frank Lee", "frank-old@example.com"),
+        ("Grace Kim", "grace@example.com"),
+    ]
+    for index, (name, email) in enumerate(authors):
+        (repo_path / f"file_{index}.py").write_text(f"value = {index}\n")
+        run(["git", "add", "."])
+        run(["git", "commit", "-m", f"feat: commit {index}"], env_override=identity(name, email))
+
+    (repo_path / ".mailmap").write_text(
+        "# Canonical identities for this repository\n"
+        "\n"
+        "Dan Brown <dan@newcorp.com> Daniel Brown <daniel@oldcorp.com>\n"
+        "<frank@example.com> <frank-old@example.com>\n"
+        "Grace Kim-Watanabe <grace@example.com>  # married name\n"
+    )
+
+    return repo_path
+
+
+@pytest.mark.integration
+class TestMailmapFourFieldForm:
+    """Tests for the four-field form: matched on commit name and email together."""
+
+    def test_four_field_form_maps_old_name_and_email_to_canonical_identity(
+        self, four_field_repo: Path
+    ) -> None:
+        reader = GitReader(four_field_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        daniel = next(c for c in commits if c.author_email == "dan@newcorp.com")
+        assert daniel.author_name == "Dan Brown"
+
+    def test_four_field_form_leaves_a_different_name_on_the_same_address(
+        self, four_field_repo: Path
+    ) -> None:
+        """Erica shares Daniel's address and must not be rewritten as Daniel."""
+        reader = GitReader(four_field_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        erica = next(c for c in commits if c.author_name == "Erica Stone")
+        assert erica.author_email == "daniel@oldcorp.com"
+
+    def test_four_field_and_three_field_coexist_in_same_mailmap(
+        self, four_field_repo: Path
+    ) -> None:
+        """Every form in one file is parsed; none shadows another."""
+        reader = GitReader(four_field_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        identities = {(c.author_name, c.author_email) for c in commits}
+        assert identities == {
+            ("Dan Brown", "dan@newcorp.com"),
+            ("Erica Stone", "daniel@oldcorp.com"),
+            ("Frank Lee", "frank@example.com"),
+            ("Grace Kim-Watanabe", "grace@example.com"),
+        }
+
+
+@pytest.mark.integration
+class TestMailmapEmailOnlyForm:
+    """Tests for the email-only form: `<proper@email> <commit@email>`."""
+
+    def test_email_is_replaced_and_commit_name_preserved(self, four_field_repo: Path) -> None:
+        reader = GitReader(four_field_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        frank = next(c for c in commits if c.author_email == "frank@example.com")
+        assert frank.author_name == "Frank Lee"
+
+    def test_email_only_form_does_not_leak_angle_brackets_into_the_name(
+        self, four_field_repo: Path
+    ) -> None:
+        """Regression: the line was previously parsed as a name-only entry,
+        yielding the literal '<frank@example.com>' as a display name."""
+        reader = GitReader(four_field_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        assert not any("<" in c.author_name for c in commits)
+
+
+@pytest.mark.integration
+class TestMailmapComments:
+    """Tests for Git's comment handling in .mailmap."""
+
+    def test_trailing_comment_is_stripped_from_an_entry(self, four_field_repo: Path) -> None:
+        reader = GitReader(four_field_repo)
+        commits = reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
+        grace = next(c for c in commits if c.author_email == "grace@example.com")
+        assert grace.author_name == "Grace Kim-Watanabe"

--- a/tests/unit/adapters/test_git_reader.py
+++ b/tests/unit/adapters/test_git_reader.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from reveille.adapters.git_reader import (
+    _Mailmap,
     _normalise_github_noreply,
     _resolve_identity,
     _sum_numstat,
@@ -115,19 +116,21 @@ class TestResolveIdentity:
     """Tests for _resolve_identity, mailmap and noreply resolution combined."""
 
     def test_unmapped_ordinary_address_passes_through(self) -> None:
-        assert _resolve_identity("Alice", "alice@example.com", {}) == (
+        assert _resolve_identity("Alice", "alice@example.com", _Mailmap()) == (
             "Alice",
             "alice@example.com",
         )
 
     def test_unmapped_noreply_address_is_normalised(self) -> None:
-        assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", {}) == (
+        assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", _Mailmap()) == (
             "Alice",
             "alice@users.noreply.github.com",
         )
 
     def test_mailmap_entry_on_raw_address_wins(self) -> None:
-        mailmap = {"99+alice@users.noreply.github.com": ("Alice Real", "alice@example.com")}
+        mailmap = _Mailmap(
+            by_email={"99+alice@users.noreply.github.com": ("Alice Real", "alice@example.com")}
+        )
         assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", mailmap) == (
             "Alice Real",
             "alice@example.com",
@@ -135,24 +138,28 @@ class TestResolveIdentity:
 
     def test_mailmap_entry_on_normalised_address_also_matches(self) -> None:
         # An entry written against the legacy form catches the prefixed form.
-        mailmap = {"alice@users.noreply.github.com": ("Alice Real", "alice@example.com")}
+        mailmap = _Mailmap(
+            by_email={"alice@users.noreply.github.com": ("Alice Real", "alice@example.com")}
+        )
         assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", mailmap) == (
             "Alice Real",
             "alice@example.com",
         )
 
     def test_raw_mailmap_entry_takes_precedence_over_normalised(self) -> None:
-        mailmap = {
-            "99+alice@users.noreply.github.com": ("Raw Match", "raw@example.com"),
-            "alice@users.noreply.github.com": ("Normalised Match", "norm@example.com"),
-        }
+        mailmap = _Mailmap(
+            by_email={
+                "99+alice@users.noreply.github.com": ("Raw Match", "raw@example.com"),
+                "alice@users.noreply.github.com": ("Normalised Match", "norm@example.com"),
+            }
+        )
         assert _resolve_identity("Alice", "99+alice@users.noreply.github.com", mailmap) == (
             "Raw Match",
             "raw@example.com",
         )
 
     def test_mailmap_lookup_is_case_insensitive_on_the_raw_address(self) -> None:
-        mailmap = {"alice@example.com": ("Alice Real", "alice@example.com")}
+        mailmap = _Mailmap(by_email={"alice@example.com": ("Alice Real", "alice@example.com")})
         assert _resolve_identity("Alice", "ALICE@example.com", mailmap) == (
             "Alice Real",
             "alice@example.com",
@@ -160,8 +167,84 @@ class TestResolveIdentity:
 
     def test_mailmap_target_that_is_a_noreply_address_is_left_alone(self) -> None:
         # The mailmap states intent explicitly; it is not second-guessed.
-        mailmap = {"alice@example.com": ("Alice", "7+alice@users.noreply.github.com")}
+        mailmap = _Mailmap(
+            by_email={"alice@example.com": ("Alice", "7+alice@users.noreply.github.com")}
+        )
         assert _resolve_identity("Alice", "alice@example.com", mailmap) == (
             "Alice",
             "7+alice@users.noreply.github.com",
         )
+
+
+@pytest.mark.unit
+class TestResolveIdentityFourFieldForm:
+    """Tests for the four-field form, which matches on name and email together."""
+
+    def test_four_field_entry_matches_when_name_and_email_agree(self) -> None:
+        mailmap = _Mailmap(
+            by_name_and_email={
+                ("daniel brown", "daniel@oldcorp.com"): ("Dan Brown", "dan@newcorp.com")
+            }
+        )
+        assert _resolve_identity("Daniel Brown", "daniel@oldcorp.com", mailmap) == (
+            "Dan Brown",
+            "dan@newcorp.com",
+        )
+
+    def test_four_field_entry_ignored_when_the_name_differs(self) -> None:
+        """The whole point of the form: a shared address, distinguished by name."""
+        mailmap = _Mailmap(
+            by_name_and_email={
+                ("daniel brown", "shared@corp.com"): ("Dan Brown", "dan@newcorp.com")
+            }
+        )
+        assert _resolve_identity("Erica Stone", "shared@corp.com", mailmap) == (
+            "Erica Stone",
+            "shared@corp.com",
+        )
+
+    def test_four_field_matching_is_case_insensitive_on_both_fields(self) -> None:
+        mailmap = _Mailmap(
+            by_name_and_email={
+                ("commit name", "commit@email.xx"): ("Proper Name", "proper@email.xx")
+            }
+        )
+        assert _resolve_identity("CoMmIt NaMe", "CoMmIt@EmAiL.xX", mailmap) == (
+            "Proper Name",
+            "proper@email.xx",
+        )
+
+    def test_four_field_entry_wins_over_an_email_only_entry(self) -> None:
+        """Git prefers the most specific match; name plus email is more specific."""
+        mailmap = _Mailmap(
+            by_email={"shared@corp.com": ("Generic", "generic@corp.com")},
+            by_name_and_email={
+                ("daniel brown", "shared@corp.com"): ("Dan Brown", "dan@newcorp.com")
+            },
+        )
+        assert _resolve_identity("Daniel Brown", "shared@corp.com", mailmap) == (
+            "Dan Brown",
+            "dan@newcorp.com",
+        )
+        # A different contributor on the same address still falls back.
+        assert _resolve_identity("Erica Stone", "shared@corp.com", mailmap) == (
+            "Generic",
+            "generic@corp.com",
+        )
+
+
+@pytest.mark.unit
+class TestResolveIdentityEmailOnlyForm:
+    """Tests for the email-only form, which replaces the address but keeps the name."""
+
+    def test_commit_name_is_preserved(self) -> None:
+        mailmap = _Mailmap(by_email={"commit@example.com": (None, "proper@example.com")})
+        assert _resolve_identity("Alice", "commit@example.com", mailmap) == (
+            "Alice",
+            "proper@example.com",
+        )
+
+    def test_each_commit_keeps_its_own_name(self) -> None:
+        mailmap = _Mailmap(by_email={"shared@example.com": (None, "proper@example.com")})
+        assert _resolve_identity("Alice", "shared@example.com", mailmap)[0] == "Alice"
+        assert _resolve_identity("Bob", "shared@example.com", mailmap)[0] == "Bob"


### PR DESCRIPTION
### Summary
- Implemented full gitmailmap(5) specification: name-only, email-only, three-field, and four-field forms.
- Parser refactored to _Mailmap dataclass with two lookup tables; resolves most specific match first.
- Comments now run to end-of-line; names match case-insensitively.
- Fixed live bug: email-only form falling through to name-only regex, producing garbage contributor names.
- Verified against git itself: Reveille output identical to git log --use-mailmap.

### Verification
- Ruff clean, mypy strict, all 9 pre-commit hooks pass.
- 258 tests (+12), coverage 93.39% (git_reader 94.63%, init 88.57%).
- Built repo exercising every form; Reveille output identical to git log --use-mailmap.

### Notes
- Four-field form uniquely disentangles contributors sharing one address, not merely simultaneous name+email changes.
- init --mailmap template corrected: nine distinct examples, no collisions.
- Next in Phase 1: fix/bus-factor-honesty (E2E plan §5.6).
