### PR TITLE
fix/bus-factor-honesty: report commit concentration under a name that describes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking (JSON output):** the derived metric previously reported as
+  `bus_factor` is now `commit_concentration`. The computation is unchanged —
+  the minimum number of contributors whose combined commit volume reaches 50
+  percent of the total — but the old name claimed something the number does
+  not measure. Bus factor is knowledge concentration: how much of the
+  surviving code only one person understands. That is a property of line
+  ownership, answerable only by `git blame` across every file, and commit
+  counts are a weak proxy for it — a contributor making many small commits
+  outranks one who wrote a subsystem in a few large ones, and work since
+  rewritten still counts in full. The HTML summary card is relabelled
+  "Commit Concentration" and the User Guide explains what the number does and
+  does not support. Consumers reading the JSON `derived.bus_factor` key must
+  update to `derived.commit_concentration`.
+
 ### Added
 
 - Complete `.mailmap` support. All four forms documented in gitmailmap(5) are

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Reveille is designed for developers, engineering managers, and technical leads w
 - Aggregate weekly commit timeline and per-contributor commit frequency chart, enabling direct comparison of burst contributors versus contributors with sustained low-volume engagement across the analysis window
 - Per-contributor breakdowns covering commits, lines added and removed, and active day counts
 - A structured ranking table assigning each contributor a tier designation based on weighted activity metrics
-- Repository health indicators including bus factor, longest inactive streak, and consistency scores
+- Repository activity indicators including commit concentration, longest inactive streak, and consistency scores
 - Machine-readable output in JSON (ranked contributor statistics and repository metadata) and CSV (contributor table with BOM encoding for Excel compatibility) via `--format json`, `--format csv`
 
 **Design constraints that are non-negotiable:**
@@ -211,7 +211,7 @@ The generated HTML file is structured as a formal report with the following sect
 
 **Contribution Breakdown Charts** — Horizontal bar charts of commits and lines changed per contributor, and two donut charts showing each contributor's proportional share of total commits and total lines changed.
 
-**Repository Health Indicators** — Bus factor estimate (minimum number of contributors accounting for 50% of commits) and longest inactive streak within the analysis window.
+**Repository Activity Indicators** — Commit concentration (the minimum number of contributors accounting for 50% of commits) and longest inactive streak within the analysis window. Commit concentration is a measure of how concentrated the commit history is, not a bus factor: bus factor is a property of line ownership across the surviving codebase, which commit counts cannot establish. See the [User Guide](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/USER_GUIDE.md#repository-summary) for how to read it.
 
 **JSON export** — When `--format json` is used, a structured JSON file is written at the same path stem as the HTML output. The payload contains repository metadata, ranked contributor statistics with all scoring fields, and derived health metrics. Suitable for dashboards, data warehouses, and CI integrations without parsing HTML.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -52,7 +52,7 @@ a contributor ranked Captain in a ten-person team may rank Sergeant in a
 thirty-person team analysed over a longer window.
 
 Fourth, the Renderer assembles all data, computes derived metrics such as
-bus factor and longest inactive streak, builds Plotly chart specifications,
+commit concentration and longest inactive streak, builds Plotly chart specifications,
 and writes a single self-contained HTML file. All JavaScript and chart
 data are embedded inline. The output file has no external dependencies and
 can be opened in any modern browser without an internet connection.
@@ -304,13 +304,24 @@ configuration file and as a CLI flag, the CLI flag takes precedence.
 
 The summary cards at the top of the report provide four at-a-glance
 metrics. Total commits and unique contributors reflect the analysis
-window after all filters have been applied. Bus factor is the minimum
-number of contributors whose combined commit volume accounts for at least
-50 percent of total commits — a bus factor of 1 means a single person is
-responsible for the majority of the codebase's history, which represents
-a concentration risk. Max inactive days is the longest consecutive
-calendar period within the analysis window on which no commits were
-recorded.
+window after all filters have been applied. Commit concentration is the
+minimum number of contributors whose combined commit volume accounts for
+at least 50 percent of total commits — a value of 1 means a single person
+authored the majority of the history in the analysis window. Max inactive
+days is the longest consecutive calendar period within the analysis window
+on which no commits were recorded.
+
+**Commit concentration is not a bus factor, and should not be read as one.**
+Bus factor asks how much of the surviving code only one person understands.
+That is a property of line ownership — who wrote the code that is still in
+the repository today — and answering it requires `git blame` across every
+file, not commit counts. Commit volume is a weak proxy: a contributor who
+makes many small commits outranks one who wrote an entire subsystem in a
+handful of large ones, and a contributor whose work has since been rewritten
+still counts in full. Treat a low value as a prompt to look at who owns which
+files, not as a measurement of that risk. Reveille reports this metric under
+a name that describes what it actually computes; before v0.7.0 it was
+labelled "bus factor", which overstated it.
 
 ### Activity Heatmap
 

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -219,7 +219,7 @@ class Renderer:
                 for i, r in enumerate(data.ranked_contributors)
             ],
             "derived": {
-                "bus_factor": derived["bus_factor"],
+                "commit_concentration": derived["commit_concentration"],
                 "longest_inactive_streak": derived["longest_inactive_streak"],
             },
         }
@@ -312,7 +312,7 @@ class Renderer:
             A dict of derived metric names to values for template use.
         """
         return {
-            "bus_factor": _compute_bus_factor(data.ranked_contributors),
+            "commit_concentration": _compute_commit_concentration(data.ranked_contributors),
             "longest_inactive_streak": _compute_longest_inactive_streak(
                 data.commits,
                 data.metadata.analysis_since,
@@ -721,12 +721,20 @@ def _build_lines_share_pie(ranked: list[RankedContributor]) -> str:
 # ------------------------------------------------------------------
 
 
-def _compute_bus_factor(ranked: list[RankedContributor]) -> int:
-    """Compute the bus factor for the contributor population.
+def _compute_commit_concentration(ranked: list[RankedContributor]) -> int:
+    """Count the contributors who between them authored half the commits.
 
-    The bus factor is the minimum number of contributors whose combined
-    commit volume accounts for at least 50 percent of total commits.
-    A lower value indicates higher concentration risk.
+    The minimum number of contributors whose combined commit volume
+    accounts for at least 50 percent of total commits. A lower value
+    indicates a more concentrated history.
+
+    This is deliberately not called a bus factor. Bus factor is a measure
+    of knowledge concentration — how much of the surviving code only one
+    person understands — which is a property of line ownership, obtained
+    from `git blame`, not of commit counts. Commit volume is a weak proxy
+    for it: a contributor with many small commits outranks one who wrote
+    a subsystem in a handful of large ones. The honest name is the one
+    that describes what is actually measured.
 
     Args:
         ranked: Ranked contributor list.

--- a/src/reveille/templates/report.html.j2
+++ b/src/reveille/templates/report.html.j2
@@ -526,8 +526,8 @@
             <div class="label">Contributors</div>
         </div>
         <div class="summary-card">
-            <div class="value">{{ derived.bus_factor }}</div>
-            <div class="label">Bus Factor</div>
+            <div class="value">{{ derived.commit_concentration }}</div>
+            <div class="label">Commit Concentration</div>
         </div>
         <div class="summary-card">
             <div class="value">{{ derived.longest_inactive_streak }}</div>

--- a/tests/unit/adapters/test_renderer.py
+++ b/tests/unit/adapters/test_renderer.py
@@ -29,7 +29,7 @@ from reveille.adapters.renderer import (
     _build_heatmap_data,
     _build_lines_share_pie,
     _build_timeline_chart,
-    _compute_bus_factor,
+    _compute_commit_concentration,
     _compute_longest_inactive_streak,
     _sanitise_chart_label,
     _to_json,
@@ -144,6 +144,18 @@ class TestRenderJson:
         assert "contributors" in parsed
         assert "derived" in parsed
 
+    def test_derived_metrics_use_the_honest_key_names(self, tmp_path: Path) -> None:
+        """The payload reports commit concentration, never 'bus_factor'.
+
+        The old key claimed to measure knowledge concentration while
+        computing commit share. Consumers must not see it again.
+        """
+        output = tmp_path / "report.json"
+        self._renderer().render_json(self._sample_data(), output)
+        derived = json.loads(output.read_text(encoding="utf-8"))["derived"]
+        assert "commit_concentration" in derived
+        assert "bus_factor" not in derived
+
     def test_dates_serialised_as_iso_strings(self, tmp_path: Path) -> None:
         output = tmp_path / "report.json"
         self._renderer().render_json(self._sample_data(), output)
@@ -235,27 +247,27 @@ class TestRenderCsv:
 
 
 # ------------------------------------------------------------------
-# _compute_bus_factor
+# _compute_commit_concentration
 # ------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestComputeBusFactor:
-    """Tests for the bus factor derived metric helper."""
+class TestComputeCommitConcentration:
+    """Tests for the commit concentration derived metric helper."""
 
     def test_empty_ranked_returns_zero(self) -> None:
-        assert _compute_bus_factor([]) == 0
+        assert _compute_commit_concentration([]) == 0
 
     def test_single_contributor_returns_one(self) -> None:
         ranked = [_make_ranked("Alice", commit_count=20)]
-        assert _compute_bus_factor(ranked) == 1
+        assert _compute_commit_concentration(ranked) == 1
 
     def test_two_equal_contributors_returns_one(self) -> None:
         ranked = [
             _make_ranked("Alice", commit_count=10),
             _make_ranked("Bob", commit_count=10),
         ]
-        assert _compute_bus_factor(ranked) == 1
+        assert _compute_commit_concentration(ranked) == 1
 
     def test_skewed_distribution_returns_one(self) -> None:
         ranked = [
@@ -263,7 +275,7 @@ class TestComputeBusFactor:
             _make_ranked("Bob", commit_count=5),
             _make_ranked("Carol", commit_count=5),
         ]
-        assert _compute_bus_factor(ranked) == 1
+        assert _compute_commit_concentration(ranked) == 1
 
     def test_even_distribution_across_four_returns_two(self) -> None:
         ranked = [
@@ -272,11 +284,11 @@ class TestComputeBusFactor:
             _make_ranked("Carol", commit_count=25),
             _make_ranked("Dan", commit_count=25),
         ]
-        assert _compute_bus_factor(ranked) == 2
+        assert _compute_commit_concentration(ranked) == 2
 
     def test_zero_total_commits_returns_zero(self) -> None:
         ranked = [_make_ranked("Alice", commit_count=0)]
-        assert _compute_bus_factor(ranked) == 0
+        assert _compute_commit_concentration(ranked) == 0
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
### Summary
- Renamed bus factor metric to commit concentration; computation unchanged.
- JSON field derived.bus_factor → derived.commit_concentration.
- HTML card relabelled 'Commit Concentration'.
- Docstring and docs updated to explain why metric is not called bus factor.

### Verification
- Ruff clean, mypy strict, all 9 pre-commit hooks pass.
- 259 tests passing (+1).
- End-to-end verified: JSON emits commit_concentration, HTML card reads 'Commit Concentration', zero occurrences of 'Bus Factor' remain.

### Notes
- Breaking change to JSON contract; flagged in changelog. Pre-1.0 and deliberate.
- Correct branch of the fork: computing bus factor properly requires git blame, which is costly and not justified for most users.
- Next branch: docs/v0.7.0-pre-release to fix outdated mailmap note and prepare release.
