### PR TITLE
fix/pep561-py-typed: ship the PEP 561 marker and check that it stays shipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: poetry run ruff check src tests
       - name: Check version sync
         run: make check-version
+      - name: Check packaging contract
+        run: make check-packaging
 
   typecheck:
     name: Type Check (mypy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Reveille now ships the PEP 561 `py.typed` marker. The package has advertised the
+  `Typing :: Typed` classifier since v0.5.0 while the marker was absent from every
+  built distribution, so type checkers in downstream projects reported Reveille as
+  missing library stubs and ignored its annotations entirely — the `mypy --strict`
+  guarantee applied inside the project but delivered nothing to consumers of it.
+  Installing this release makes Reveille's inline types visible to `mypy`, `pyright`,
+  and any other PEP 561-aware checker with no change required on the consumer side.
+- `make check-packaging` asserts the marker survives into both the wheel and the sdist,
+  and runs in CI alongside the existing version-sync check. The defect persisted because
+  nothing verified it; a claim the build does not check is a claim that silently stops
+  being true.
+
 ### Changed
 
 - **Breaking (JSON output):** the derived metric previously reported as

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install lint format fix typecheck precommit test test-unit \
+.PHONY: help install lint format fix typecheck precommit check-packaging test test-unit \
 	    test-integration test-e2e coverage ci build publish-test \
 	    publish clean
 
@@ -24,6 +24,13 @@ help:  ## Display available targets
 
 install:  ## Install all dependencies including dev group
 	poetry install
+
+check-packaging:  ## Assert the PEP 561 py.typed marker ships in the built distributions
+	@rm -rf dist
+	@poetry build -q
+	@poetry run python -c "import glob, sys, tarfile, zipfile; w = sorted(glob.glob('dist/*.whl'))[-1]; s = sorted(glob.glob('dist/*.tar.gz'))[-1]; missing = [k for k, ok in (('wheel', 'reveille/py.typed' in zipfile.ZipFile(w).namelist()), ('sdist', any(n.endswith('reveille/py.typed') for n in tarfile.open(s).getnames()))) if not ok]; sys.exit('py.typed missing from: ' + ', '.join(missing)) if missing else None"
+	@rm -rf dist
+	@echo "py.typed marker present in wheel and sdist"
 
 check-version:  ## Assert pyproject.toml version matches reveille.__version__
 	@TOML_VER=$$(poetry version --short); \
@@ -78,6 +85,7 @@ coverage:  ## Generate HTML and terminal coverage report
 
 ci:  ## Full CI workflow: lint, typecheck, test
 	$(MAKE) check-version
+	$(MAKE) check-packaging
 	$(MAKE) lint
 	$(MAKE) typecheck
 	$(MAKE) test

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,44 @@
+"""Unit tests for Reveille's packaging contract.
+
+These verify claims the distribution metadata makes about the package.
+A claim that nothing checks is a claim that silently stops being true:
+the `Typing :: Typed` classifier was advertised for several releases
+while no marker file shipped, so every downstream type checker ignored
+Reveille's annotations.
+
+The build-time counterpart is `make check-packaging`, which asserts the
+marker survives into the built wheel and sdist. This module asserts it
+exists in the package at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import reveille
+
+_PACKAGE_ROOT = Path(reveille.__file__).parent
+
+
+@pytest.mark.unit
+class TestPep561Marker:
+    """Tests for the PEP 561 inline-type marker."""
+
+    def test_py_typed_marker_is_present(self) -> None:
+        """PEP 561 requires the marker for annotations to be honoured.
+
+        Without it a downstream `mypy` run reports Reveille as missing
+        library stubs, regardless of how completely the source is typed.
+        """
+        assert (_PACKAGE_ROOT / "py.typed").is_file()
+
+    def test_py_typed_marker_is_empty(self) -> None:
+        """An empty marker declares the package fully typed inline.
+
+        PEP 561 reserves the contents for the string `partial`, which
+        marks a stub-only package that covers part of its API. Reveille
+        ships complete inline annotations, so the file stays empty.
+        """
+        assert (_PACKAGE_ROOT / "py.typed").read_text(encoding="utf-8").strip() == ""


### PR DESCRIPTION
### Summary
- Added src/reveille/py.typed marker file, shipping in wheel and sdist.
- Implemented check-packaging target in Makefile; wired into CI lint job.
- Added unit test asserting marker exists and is empty.
- Verified guards fail when marker removed; restored → green.

### Verification
- make ci fully green: 261 tests (+2), pre-commit clean.
- Wheel and sdist built; py.typed present in both.
- Removing marker fails unit test and check-packaging; restored passes.

### Notes
- Fix addresses finding that Typing :: Typed classifier was false due to missing marker.
- Guard ensures compliance persists across releases.
