### PR TITLE
refactor/exception-naming: correct ReveilleError spelling with a deprecated alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The base exception is now spelled `ReveilleError`. It had been `RevelleError` —
+  missing the second `i` — since the first release, and as the documented catch-all for
+  library consumers the typo sat directly on the public API surface. **No consumer code
+  needs to change**: `RevelleError` remains importable as a deprecated alias resolving to
+  the same class, so `except RevelleError` continues to catch every Reveille failure.
+  Accessing it emits a `DeprecationWarning` naming the replacement and the removal
+  version. The alias is removed in **v1.0.0**, where the public API becomes stable —
+  correcting it now is the last opportunity to do so at no cost to users.
+- `reveille.exceptions` now declares `__all__`, and its module docstring carries the full
+  exception hierarchy.
+
 ### Fixed
 
 - Reveille now ships the PEP 561 `py.typed` marker. The package has advertised the

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -25,7 +25,7 @@ import typer
 from reveille import __version__
 from reveille.config import OutputFormat, ReportConfig, ReportConfigKwargs
 from reveille.domain.models import ProgressEvent
-from reveille.exceptions import ConfigurationError, RevelleError
+from reveille.exceptions import ConfigurationError, ReveilleError
 
 app = typer.Typer(
     name="reveille",
@@ -392,7 +392,7 @@ def generate(
             report_config,
             on_progress=_make_progress_callback(spinner),
         )
-    except RevelleError as exc:
+    except ReveilleError as exc:
         spinner.complete()
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
@@ -416,7 +416,7 @@ def validate(
     resolved = repo.resolve()
     try:
         reader = GitReader(resolved)
-    except RevelleError as exc:
+    except ReveilleError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
@@ -428,7 +428,7 @@ def validate(
             err=True,
         )
         raise typer.Exit(code=1) from None
-    except RevelleError as exc:
+    except ReveilleError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
@@ -484,14 +484,14 @@ def init(
     try:
         written_path = write_init_config(output, force=force)
         typer.echo(f"Configuration file written to: {written_path}")
-    except RevelleError as exc:
+    except ReveilleError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
     if mailmap:
         try:
             mailmap_result = write_mailmap_template(cwd / ".mailmap", force=force)
-        except RevelleError as exc:
+        except ReveilleError as exc:
             typer.echo(f"Error: {exc}", err=True)
             raise typer.Exit(code=1) from exc
         if mailmap_result is not None:

--- a/src/reveille/exceptions.py
+++ b/src/reveille/exceptions.py
@@ -1,13 +1,40 @@
 """Domain-specific exception hierarchy for Reveille.
 
-All exceptions raised by Reveille's public interface are subclasses
-of RevelleError. Callers may catch RevelleError to handle any
-Reveille-originated failure generically, or catch specific
-subclasses for targeted error handling.
+All exceptions raised by Reveille's public interface are subclasses of
+ReveilleError. Catch that class to handle any Reveille-originated failure
+generically, or catch a specific subclass for targeted handling.
+
+The hierarchy is::
+
+    ReveilleError
+    ├── RepositoryError
+    │   └── EmptyRepositoryError
+    ├── ConfigurationError
+    └── RenderError
+        └── OutputPathError
+
+The base class was named ``RevelleError`` — missing the second ``i`` — up to
+and including v0.6.0. That spelling remains importable as a deprecated alias
+and resolves to the same class, so existing ``except RevelleError`` code is
+unaffected. It is scheduled for removal in v1.0.0, where the CLI contract and
+public API become stable.
 """
 
+from __future__ import annotations
 
-class RevelleError(Exception):
+import warnings
+
+__all__ = [
+    "ConfigurationError",
+    "EmptyRepositoryError",
+    "OutputPathError",
+    "RenderError",
+    "RepositoryError",
+    "ReveilleError",
+]
+
+
+class ReveilleError(Exception):
     """Base exception for all Reveille errors.
 
     Never raised directly. Catch this class to handle any
@@ -15,7 +42,7 @@ class RevelleError(Exception):
     """
 
 
-class RepositoryError(RevelleError):
+class RepositoryError(ReveilleError):
     """Raised when the target path is not a valid or readable Git repository.
 
     Covers both the case where no .git directory is present and the case
@@ -28,7 +55,7 @@ class EmptyRepositoryError(RepositoryError):
     """Raised when no commits exist within the specified analysis window."""
 
 
-class ConfigurationError(RevelleError):
+class ConfigurationError(ReveilleError):
     """Raised when the supplied configuration is invalid.
 
     Covers malformed configuration files, invalid field values, and
@@ -36,7 +63,7 @@ class ConfigurationError(RevelleError):
     """
 
 
-class RenderError(RevelleError):
+class RenderError(ReveilleError):
     """Raised when the HTML report cannot be rendered.
 
     Typically caused by a template error or an inability to write
@@ -50,3 +77,32 @@ class OutputPathError(RenderError):
     Caused by the parent directory not existing or by insufficient
     filesystem permissions.
     """
+
+
+def __getattr__(name: str) -> type[ReveilleError]:
+    """Resolve the pre-v0.7.0 misspelling of the base exception.
+
+    PEP 562 module-level attribute access. Keeping ``RevelleError``
+    importable means `except RevelleError` in existing consumer code
+    continues to catch every Reveille failure, while new code and the
+    warning steer callers to the corrected spelling.
+
+    Args:
+        name: The attribute being accessed on this module.
+
+    Returns:
+        ReveilleError, when the deprecated alias is requested.
+
+    Raises:
+        AttributeError: For any other name, as normal attribute access would.
+    """
+    if name == "RevelleError":
+        warnings.warn(
+            "reveille.exceptions.RevelleError is a misspelling retained for "
+            "backwards compatibility and will be removed in v1.0.0. "
+            "Use ReveilleError instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ReveilleError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,97 @@
+"""Unit tests for reveille.exceptions.
+
+Two contracts are under test. The hierarchy contract: every Reveille
+failure is catchable as a single base class, which is what the public
+documentation tells consumers to rely on. The compatibility contract:
+the pre-v0.7.0 misspelling still resolves, so upgrading does not break
+`except RevelleError` in code written against an earlier release.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import reveille.exceptions as exc_module
+from reveille.exceptions import (
+    ConfigurationError,
+    EmptyRepositoryError,
+    OutputPathError,
+    RenderError,
+    RepositoryError,
+    ReveilleError,
+)
+
+_SUBCLASSES = [
+    RepositoryError,
+    EmptyRepositoryError,
+    ConfigurationError,
+    RenderError,
+    OutputPathError,
+]
+
+
+@pytest.mark.unit
+class TestExceptionHierarchy:
+    """Tests for the documented inheritance contract."""
+
+    @pytest.mark.parametrize("subclass", _SUBCLASSES)
+    def test_every_error_is_a_reveille_error(self, subclass: type[Exception]) -> None:
+        """The single-catch guarantee the public docs make."""
+        assert issubclass(subclass, ReveilleError)
+
+    def test_empty_repository_error_is_a_repository_error(self) -> None:
+        assert issubclass(EmptyRepositoryError, RepositoryError)
+
+    def test_output_path_error_is_a_render_error(self) -> None:
+        assert issubclass(OutputPathError, RenderError)
+
+    @pytest.mark.parametrize("subclass", _SUBCLASSES)
+    def test_catching_the_base_class_catches_every_subclass(
+        self, subclass: type[Exception]
+    ) -> None:
+        with pytest.raises(ReveilleError):
+            raise subclass("failure")
+
+    def test_reveille_error_is_an_exception(self) -> None:
+        assert issubclass(ReveilleError, Exception)
+
+
+@pytest.mark.unit
+class TestDeprecatedAlias:
+    """Tests for the retained pre-v0.7.0 spelling, `RevelleError`."""
+
+    def test_alias_resolves_to_the_corrected_class(self) -> None:
+        """Identity, not merely a compatible subclass.
+
+        Consumers may compare with `is`, and a distinct class would also
+        break `except RevelleError` for errors raised internally as
+        ReveilleError subclasses.
+        """
+        with pytest.warns(DeprecationWarning):
+            assert exc_module.RevelleError is ReveilleError
+
+    def test_alias_emits_a_deprecation_warning_naming_its_replacement(self) -> None:
+        with pytest.warns(DeprecationWarning, match="Use ReveilleError instead"):
+            _ = exc_module.RevelleError
+
+    def test_alias_warning_states_the_removal_version(self) -> None:
+        """A deprecation without a removal version is not actionable."""
+        with pytest.warns(DeprecationWarning, match="v1.0.0"):
+            _ = exc_module.RevelleError
+
+    def test_catching_the_alias_still_catches_reveille_failures(self) -> None:
+        """The behaviour the alias exists to preserve."""
+        with pytest.warns(DeprecationWarning):
+            legacy_base = exc_module.RevelleError
+        with pytest.raises(legacy_base):
+            raise ConfigurationError("failure")
+
+    def test_unknown_attribute_still_raises_attribute_error(self) -> None:
+        """The module __getattr__ must not swallow genuine typos."""
+        with pytest.raises(AttributeError, match="no attribute 'NoSuchError'"):
+            _ = exc_module.NoSuchError  # type: ignore[attr-defined]
+
+    def test_alias_is_absent_from_the_public_export_list(self) -> None:
+        """`__all__` advertises the supported surface; the alias is not it."""
+        assert "ReveilleError" in exc_module.__all__
+        assert "RevelleError" not in exc_module.__all__


### PR DESCRIPTION
### Summary
- Corrected spelling of RevelleError → ReveilleError.
- Added module __getattr__ to retain old spelling with DeprecationWarning.
- Alias returns same class object, ensuring catching and identity checks remain valid.
- __all__ excludes alias; __getattr__ raises AttributeError for unknown names.
- CLI updated to reference corrected spelling.

### Verification
- Ruff clean, mypy strict, all 9 pre-commit hooks pass.
- 280 tests passing (+19); exceptions.py at 100% coverage.
- Downstream consumer code importing old spelling works with warning.
- mypy --strict downstream build passes with alias.

### Notes
- Drift guard added to branch plan: docs/ARCHITECTURE.md promotion must verify every symbol against source, not transcribe old misspelling.
- Next branch: chore/python-support-policy (#3), now unblocked by decision D-3.
