### PR TITLE
chore/python-support-policy: test and advertise 3.11 through 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,14 @@ jobs:
     permissions:
       contents: read
     strategy:
+      # Report every failing interpreter, not just the first. When a new
+      # CPython is added to the matrix, knowing whether it broke alone or
+      # alongside others is the whole diagnostic.
+      fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        # Every non-EOL CPython at or above Reveille's 3.11 floor.
+        # See CONTRIBUTING.md, "Supported Python versions".
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Python 3.13 and 3.14 are now supported and tested. The CI matrix runs the full suite on
+  3.11, 3.12, 3.13, and 3.14, and both new versions appear in the PyPI classifiers.
+  Previously the `^3.11` constraint permitted installation on 3.13 and 3.14 while CI
+  tested only 3.11 and 3.12 and the classifiers advertised only those two — users on newer
+  interpreters were running an untested, unadvertised configuration. `CONTRIBUTING.md`
+  now states the support policy: every non-EOL CPython at or above the 3.11 floor, added
+  to the classifiers only once CI proves it, dropped on upstream EOL, and never
+  upper-capped below 4.0.
+- The CI test matrix sets `fail-fast: false`, so a failure on one interpreter no longer
+  cancels the others.
+
 ### Changed
 
 - The base exception is now spelled `ReveilleError`. It had been `RevelleError` —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,39 @@ poetry run ruff check src/
 poetry run pytest -n auto
 ```
 
+## Supported Python versions
+
+Reveille supports **every non-EOL CPython release at or above 3.11**. As of the 0.7.0
+release that is **3.11, 3.12, 3.13, and 3.14**. Each is exercised by the CI matrix on
+every pull request; each appears in the PyPI classifiers.
+
+**The 3.11 floor is technical, not a preference.** `config.py` imports `tomllib` and
+`git_reader.py` uses `datetime.UTC`, both added in 3.11. Lowering the floor means
+vendoring a TOML parser and reworking timezone handling — not worth it while 3.10 is
+weeks from end of life.
+
+Three rules govern changes to this policy.
+
+**1. A version is added to the classifiers only after CI proves it.** The classifier
+advertises a tested configuration; it is evidence, not intent. Add the version to the
+matrix, let CI run, and add the classifier in the same pull request once it is green.
+If it fails, either fix the incompatibility or state the exclusion and its reason —
+never quietly drop the version.
+
+**2. Versions are dropped on their upstream EOL date**, not on convenience. This follows
+the convention codified by SPEC 0 (successor to NEP 29) and used across the ecosystem.
+Dropping a version is a breaking change for anyone still on it and belongs in a release
+note.
+
+**3. The `python` constraint carries no upper cap below 4.0, and must not gain one.**
+`python = "^3.11"` resolves to `>=3.11,<4.0`. A tighter cap such as `<3.13` asserts that
+Reveille *breaks* on 3.13, which is a much stronger claim than "untested" — and the
+assertion is transitive: every project depending on Reveille inherits an unsatisfiable
+constraint on an interpreter that most likely works, and this project inherits the
+resulting reports. Not having tested a release is a reason to stay silent about it, not
+to forbid it. If a genuine incompatibility is found, express it as a narrow, documented
+exclusion rather than a blanket ceiling.
+
 ## Architecture
 
 Reveille follows Clean Architecture strictly. The dependency rule is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Version Control :: Git",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Build Tools",
@@ -50,6 +52,10 @@ packages = [
 # ------------------------------------------------------------------
 
 [tool.poetry.dependencies]
+# Floor is a real technical constraint, not a preference: config.py imports
+# tomllib and git_reader.py uses datetime.UTC, both added in 3.11.
+# Deliberately no upper cap below 4.0 — see CONTRIBUTING.md,
+# "Supported Python versions", for why capping is not done here.
 python = "^3.11"
 
 # CLI Layer


### PR DESCRIPTION
### Summary
- Extended CI matrix to Python 3.11–3.14; fail-fast disabled for diagnostic clarity.
- pyproject.toml updated: Requires-Python >=3.11,<4.0; caret ^3.11 constraint unchanged.
- Added classifiers for 3.13 and 3.14.
- CONTRIBUTING.md updated with explicit support policy.

### Verification
- make ci green locally (280 tests, 3.12), pre-commit clean, YAML valid.
- Wheel metadata: Requires-Python >=3.11,<4.0; classifiers 3.11–3.14.
- Dependencies declare support up to 3.14/3.15; no code hits deprecated APIs.
- Codecov upload pinned to 3.11 only; wider matrix does not double-upload.

### Notes
- Per D-3, classifiers contingent on CI run for this PR. If 3.13/3.14 fail, fix incompatibility or drop classifier with reason recorded.
- Plotly on 3.14 is the likeliest candidate for breakage; flagged in audit record.
- Next branch: feat/cli-exit-codes (#10, #11).
