### PR TITLE
feat/cli-exit-codes: separate a negative answer from an inability to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ### Added
 
+- **Exit codes now distinguish a negative answer from an inability to run.** Every
+  command returns `0` (success), `1` (Reveille ran and the repository state does not
+  satisfy the request — an empty analysis window, or a repository with no commits), or
+  `2` (Reveille could not run — invalid flag value, malformed configuration, a path that
+  is not a readable Git repository, or an unwritable output location). Previously every
+  failure returned `1`, so a CI job could not tell "this repository has nothing to report
+  yet", which may be acceptable, from "this step is misconfigured", which is not. The
+  codes are documented in the User Guide and are a supported contract. **Anyone currently
+  branching on a non-zero exit should note that configuration and repository-access
+  failures now return `2` rather than `1`.**
+- `--verbose` on `generate` and `validate` writes DEBUG-level diagnostics to stderr: the
+  fully resolved configuration after CLI flags and TOML have been merged, the exact
+  `git log` invocation, the commit count read, and every file written. Normal output is
+  unchanged, so the flag is safe to add to an existing pipeline. Reveille's modules log
+  through the standard `logging` module under the `reveille` logger and install only a
+  `NullHandler`, so importing Reveille as a library remains silent unless the host
+  application configures logging itself.
 - Python 3.13 and 3.14 are now supported and tested. The CI matrix runs the full suite on
   3.11, 3.12, 3.13, and 3.14, and both new versions appear in the PyPI classifiers.
   Previously the `^3.11` constraint permitted installation on 3.13 and 3.14 while CI
@@ -20,6 +37,13 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   upper-capped below 4.0.
 - The CI test matrix sets `fail-fast: false`, so a failure on one interpreter no longer
   cancels the others.
+
+### Fixed
+
+- A readable repository containing no commits at all now raises `EmptyRepositoryError`
+  rather than `RepositoryError`. It had surfaced as a repository-access failure because
+  `git log` errors on an unborn HEAD, which conflated "this repository is unreadable"
+  with "this repository is empty" — the two states the new exit codes exist to separate.
 
 ### Changed
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,6 +11,7 @@ the [README](../README.md).
 
 - [How Reveille Works](#how-reveille-works)
 - [CLI Flags in Depth](#cli-flags-in-depth)
+- [Exit Codes](#exit-codes)
 - [The reveille init Command](#the-reveille-init-command)
 - [TOML Configuration Reference](#toml-configuration-reference)
 - [Understanding the Report](#understanding-the-report)
@@ -185,6 +186,54 @@ Controls the output format for `reveille generate`. Accepts four values.
 reveille generate --format json --output /tmp/reports/q4.html
 reveille generate --format csv --output /tmp/reports/q4.html
 ```
+
+---
+
+## Exit Codes
+
+Every command returns one of three codes. They are a supported contract:
+the numbers will not change without a major version bump.
+
+| Code | Meaning | When |
+|---|---|---|
+| `0` | Success | The command ran and its answer is affirmative. |
+| `1` | Negative answer | Reveille ran correctly and the repository state does not satisfy the request. The analysis window contains no commits, or the repository has no commits at all. |
+| `2` | Could not run | Reveille could not perform the request. Invalid flag value, malformed configuration, a path that is not a readable Git repository, or an output location that cannot be written. |
+
+**The distinction between `1` and `2` is the one worth scripting against.** A
+negative answer may be an acceptable state to record — a newly created repository
+legitimately has nothing to report. An inability to run is a broken pipeline step
+and usually means a misconfiguration.
+
+```bash
+reveille validate --repo ./service
+case $? in
+  0) echo "has commits, proceeding" ;;
+  1) echo "no commits in range - skipping report" ;;
+  2) echo "misconfigured, failing the build" >&2; exit 1 ;;
+esac
+```
+
+Diagnostic detail beyond this three-way split is written to stderr, not encoded
+in the exit code. Adding a distinct code per cause does not scale: the range is
+small, and every new cause would break scripts branching on the old numbering.
+
+### Diagnostics
+
+Pass `--verbose` to `generate` or `validate` to write DEBUG-level diagnostics to
+stderr. Normal output is unchanged, so adding the flag is safe in an existing
+pipeline. It reports the fully resolved configuration after CLI flags and the
+TOML file have been merged, the exact `git log` invocation used, how many commits
+were read, and every file written — which is usually enough to explain an
+unexpected report without a debugger.
+
+```bash
+reveille generate --verbose 2> reveille-debug.log
+```
+
+Reveille's modules log through the standard `logging` module under the `reveille`
+logger and install no handler of their own. Importing Reveille as a library is
+therefore silent unless the host application configures logging itself.
 
 ---
 

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -2,7 +2,18 @@
 
 A CLI tool that generates self-contained HTML performance reports
 from local Git repositories.
+
+Reveille's modules emit diagnostics through the standard `logging`
+module under the `reveille` logger. A NullHandler is attached here so
+that importing Reveille as a library produces no output unless the host
+application configures a handler itself — the convention for libraries,
+which must not impose logging policy on the program embedding them. The
+CLI attaches its own stderr handler when `--verbose` is passed.
 """
+
+import logging
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __version__ = "0.6.0"
 __author__ = "Varaprasad Chilakanti"

--- a/src/reveille/adapters/git_reader.py
+++ b/src/reveille/adapters/git_reader.py
@@ -22,6 +22,7 @@ any repository large enough to care about.
 from __future__ import annotations
 
 import datetime
+import logging
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -37,6 +38,8 @@ from reveille.exceptions import EmptyRepositoryError, RepositoryError
 # ASCII 0x1E (record separator) and 0x1F (unit separator) are control
 # characters that cannot appear in a commit header field, so they parse
 # unambiguously where a printable delimiter would not.
+_logger = logging.getLogger(__name__)
+
 _RECORD_SEP = "\x1e"
 _FIELD_SEP = "\x1f"
 
@@ -263,6 +266,17 @@ class GitReader:
 
         exclude_set = {entry.lower() for entry in exclude_authors}
 
+        # An unborn HEAD means the repository is readable but has no commits
+        # at all. That is a negative answer, not a failure to read, so it
+        # must surface as EmptyRepositoryError like an empty analysis window
+        # rather than as the RepositoryError that `git log` would produce.
+        if not self._repo.head.is_valid():
+            raise EmptyRepositoryError(
+                f"Repository at '{self._repo_path}' contains no commits. "
+                "Make at least one commit before generating a report."
+            )
+
+        _logger.debug("git log %s", " ".join(log_args))
         try:
             raw_log = self._repo.git.log(*log_args)
         except GitCommandError as exc:
@@ -317,6 +331,12 @@ class GitReader:
                 "Try widening the date range or removing author filters."
             )
 
+        _logger.debug(
+            "read %d commits from %s (%d bytes of git log output)",
+            len(commits),
+            rev,
+            len(raw_log),
+        )
         return sorted(commits, key=lambda c: c.timestamp, reverse=True)
 
     def aggregate_contributor_stats(

--- a/src/reveille/cli.py
+++ b/src/reveille/cli.py
@@ -1,18 +1,23 @@
 """CLI entry point for Reveille.
 
-Defines three public commands: generate, version, validate.
+Defines the public commands: generate, validate, init, version, help.
 Responsible for flag parsing, boundary validation, constructing
 a ReportConfig, and delegating to the application service.
 Contains no business logic.
 
 Entry point registered in pyproject.toml:
     reveille = "reveille.cli:app"
+
+Exit codes are a supported contract — see `ExitCode` below and the
+"Exit Codes" section of docs/USER_GUIDE.md.
 """
 
 from __future__ import annotations
 
 import datetime
+import enum
 import itertools
+import logging
 import sys
 import threading
 import time
@@ -25,7 +30,73 @@ import typer
 from reveille import __version__
 from reveille.config import OutputFormat, ReportConfig, ReportConfigKwargs
 from reveille.domain.models import ProgressEvent
-from reveille.exceptions import ConfigurationError, ReveilleError
+from reveille.exceptions import ConfigurationError, EmptyRepositoryError, ReveilleError
+
+_logger = logging.getLogger("reveille.cli")
+
+
+class ExitCode(enum.IntEnum):
+    """Process exit codes. Part of Reveille's public CLI contract.
+
+    The split follows the convention used by `grep` and `diff`, where the
+    code distinguishes *a negative answer* from *an inability to answer*.
+    That distinction is the one a CI job acts on: a negative answer may be
+    an acceptable state to record, whereas an inability to answer is a
+    broken pipeline step.
+
+    Diagnostic detail beyond this three-way split belongs in the stderr
+    message, not in the exit code. Encoding individual causes as distinct
+    codes does not scale — the range is small, and every new cause becomes
+    a breaking change for anyone branching on the old numbering.
+    """
+
+    SUCCESS = 0
+    """The command ran and its answer is affirmative."""
+
+    NEGATIVE = 1
+    """The command ran correctly and its answer is negative.
+
+    Reveille worked as intended and the repository state does not satisfy
+    the request — currently, an analysis window containing no commits.
+    """
+
+    CANNOT_RUN = 2
+    """The command could not run at all.
+
+    Invalid invocation, invalid configuration, a path that is not a
+    readable Git repository, or an output location that cannot be written.
+    The fault is in the inputs or the environment, not in the answer.
+    """
+
+
+def _configure_logging(verbose: bool) -> None:
+    """Attach a stderr log handler when diagnostics are requested.
+
+    Reveille's library modules log through the standard `logging` module
+    and never install a handler of their own, per the convention for
+    libraries. This is the only place a handler is attached, so importing
+    Reveille as a library stays silent unless the host application opts in.
+
+    Args:
+        verbose: True to emit DEBUG-level diagnostics to stderr.
+    """
+    if not verbose:
+        return
+    package_logger = logging.getLogger("reveille")
+    # Idempotent: a second call in the same process must not duplicate
+    # every diagnostic line. Only the NullHandler installed at import
+    # time is expected to be present here.
+    if any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, logging.NullHandler)
+        for h in package_logger.handlers
+    ):
+        package_logger.setLevel(logging.DEBUG)
+        return
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    package_logger.addHandler(handler)
+    package_logger.setLevel(logging.DEBUG)
+
 
 app = typer.Typer(
     name="reveille",
@@ -210,7 +281,8 @@ def _validate_output_path(output: Path, repo_path: Path) -> None:
         repo_path: The resolved repository root used as the boundary reference.
 
     Raises:
-        typer.Exit: With code 1 if the path contains upward traversal components.
+        typer.Exit: ExitCode.CANNOT_RUN if the path contains upward
+            traversal components.
     """
     if ".." in output.parts:
         typer.echo(
@@ -218,7 +290,7 @@ def _validate_output_path(output: Path, repo_path: Path) -> None:
             "Provide an absolute path or a path relative to the current directory.",
             err=True,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.CANNOT_RUN)
 
     if not output.resolve().is_relative_to(repo_path):
         typer.echo(
@@ -340,10 +412,19 @@ def generate(
         Path | None,
         typer.Option("--config", "-c", help="Path to a TOML configuration file."),
     ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            help="Emit diagnostic logging to stderr. Does not change normal output.",
+        ),
+    ] = False,
 ) -> None:
     """Generate an HTML performance report for the target repository."""
     from reveille.config import load_config_from_toml
     from reveille.services.report import generate_report
+
+    _configure_logging(verbose)
 
     config_kwargs: ReportConfigKwargs = cast(ReportConfigKwargs, {})
     _auto_discovered = config is None
@@ -362,7 +443,7 @@ def generate(
                 )
             else:
                 typer.echo(f"Configuration error: {exc}", err=True)
-            raise typer.Exit(code=1) from exc
+            raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
 
     merged = _merge_cli_flags(
         config_kwargs,
@@ -384,7 +465,21 @@ def generate(
         report_config = ReportConfig(**merged)
     except ValueError as exc:
         typer.echo(f"Configuration error: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
+
+    _logger.debug(
+        "resolved configuration: repo=%s output=%s branch=%s since=%s until=%s "
+        "min_commits=%s exclude_authors=%s ranking_enabled=%s format=%s",
+        report_config.repo_path,
+        report_config.output_path,
+        report_config.branch,
+        report_config.since,
+        report_config.until,
+        report_config.min_commits,
+        report_config.exclude_authors,
+        report_config.ranking_enabled,
+        report_config.output_format,
+    )
 
     spinner = _StageSpinner()
     try:
@@ -392,10 +487,14 @@ def generate(
             report_config,
             on_progress=_make_progress_callback(spinner),
         )
+    except EmptyRepositoryError as exc:
+        spinner.complete()
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=ExitCode.NEGATIVE) from exc
     except ReveilleError as exc:
         spinner.complete()
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
     else:
         spinner.complete()
         for path in written_paths:
@@ -408,17 +507,24 @@ def validate(
         Path,
         typer.Option("--repo", "-r", help="Path to the Git repository root."),
     ] = Path("."),
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            help="Emit diagnostic logging to stderr. Does not change normal output.",
+        ),
+    ] = False,
 ) -> None:
     """Validate that the target path is a readable Git repository with at least one commit."""
     from reveille.adapters.git_reader import GitReader
-    from reveille.exceptions import EmptyRepositoryError
 
+    _configure_logging(verbose)
     resolved = repo.resolve()
     try:
         reader = GitReader(resolved)
     except ReveilleError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
 
     try:
         reader.read_commits(branch=None, since=None, until=None, exclude_authors=[])
@@ -427,10 +533,10 @@ def validate(
             f"Error: repository at '{resolved}' contains no commits.",
             err=True,
         )
-        raise typer.Exit(code=1) from None
+        raise typer.Exit(code=ExitCode.NEGATIVE) from None
     except ReveilleError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
 
     typer.echo(f"Repository at {resolved} is valid.")
 
@@ -475,7 +581,7 @@ def init(
             "Run reveille init from within a repository root.",
             err=True,
         )
-        raise typer.Exit(code=1)
+        raise typer.Exit(code=ExitCode.CANNOT_RUN)
 
     _validate_output_path(output, cwd)
 
@@ -486,14 +592,14 @@ def init(
         typer.echo(f"Configuration file written to: {written_path}")
     except ReveilleError as exc:
         typer.echo(f"Error: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
 
     if mailmap:
         try:
             mailmap_result = write_mailmap_template(cwd / ".mailmap", force=force)
         except ReveilleError as exc:
             typer.echo(f"Error: {exc}", err=True)
-            raise typer.Exit(code=1) from exc
+            raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc
         if mailmap_result is not None:
             typer.echo(f".mailmap template written to: {mailmap_result}")
         else:
@@ -520,7 +626,7 @@ def _parse_date(value: str, flag_name: str) -> datetime.date:
         A datetime.date instance.
 
     Raises:
-        typer.Exit: With code 1 if the format is invalid.
+        typer.Exit: ExitCode.CANNOT_RUN if the format is invalid.
     """
     try:
         return datetime.date.fromisoformat(value)
@@ -529,4 +635,4 @@ def _parse_date(value: str, flag_name: str) -> datetime.date:
             f"Error: {flag_name} must be in YYYY-MM-DD format, got '{value}'.",
             err=True,
         )
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=ExitCode.CANNOT_RUN) from exc

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -17,6 +17,7 @@ or Typer. All external concerns are delegated to adapters.
 from __future__ import annotations
 
 import datetime
+import logging
 import time
 from collections.abc import Callable
 from dataclasses import replace
@@ -27,6 +28,8 @@ from reveille.adapters.renderer import Renderer
 from reveille.config import ReportConfig
 from reveille.domain.models import ProgressEvent, RankedContributor, ReportData
 from reveille.domain.ranking import rank_contributors
+
+_logger = logging.getLogger(__name__)
 
 
 def generate_report(
@@ -51,6 +54,7 @@ def generate_report(
         OutputPathError: If the output file cannot be written.
         RenderError: If the HTML template fails to render.
     """
+    _logger.debug("pipeline start: repo=%s", config.repo_path)
     reader = GitReader(config.repo_path)
     stage_start = time.monotonic()
 
@@ -129,6 +133,11 @@ def generate_report(
         commits=commits,
     )
 
+    _logger.debug(
+        "assembled report data: %d commits, %d contributors",
+        len(commits),
+        len(contributor_stats),
+    )
     renderer = Renderer()
     paths: list[Path] = []
     if config.output_format == "html":
@@ -137,4 +146,5 @@ def generate_report(
         paths.append(renderer.render_json(report_data, config.output_path.with_suffix(".json")))
     if config.output_format == "csv":
         paths.append(renderer.render_csv(report_data, config.output_path.with_suffix(".csv")))
+    _logger.debug("wrote %d output file(s): %s", len(paths), [str(p) for p in paths])
     return paths

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -17,13 +17,14 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
 
 from reveille import __version__
-from reveille.cli import app
+from reveille.cli import ExitCode, app
 
 runner = CliRunner()
 
@@ -187,7 +188,7 @@ class TestValidateCommand:
     ) -> None:
         plain = tmp_path_factory.mktemp("plain_dir")
         result = runner.invoke(app, ["validate", "--repo", str(plain)])
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
 
     def test_non_git_directory_reports_error_in_output(
         self, tmp_path_factory: pytest.TempPathFactory
@@ -221,7 +222,7 @@ class TestValidateCommand:
             capture_output=True,
         )
         result = runner.invoke(app, ["validate", "--repo", str(empty_repo)])
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.NEGATIVE
 
 
 # ------------------------------------------------------------------
@@ -357,7 +358,7 @@ class TestGenerateCommand:
                 "not-a-date",
             ],
         )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
 
     def test_since_after_until_exits_nonzero(
         self,
@@ -379,7 +380,7 @@ class TestGenerateCommand:
                 "2024-01-01",
             ],
         )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
 
     def test_config_file_title_appears_in_output(
         self,
@@ -492,7 +493,7 @@ class TestGenerateCommand:
                 str(base / "nonexistent.toml"),
             ],
         )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
 
     def test_invalid_repo_path_exits_nonzero(
         self,
@@ -511,7 +512,7 @@ class TestGenerateCommand:
                 str(base / "report.html"),
             ],
         )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
 
     def test_output_embeds_heatmap_data_spec(self, default_report_content: str) -> None:
         """The compact heatmap data payload is embedded in the output."""
@@ -568,7 +569,7 @@ class TestGenerateCommand:
             )
         finally:
             os.chdir(original)
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
         assert "reveille init --force" in result.output
 
     def test_format_json_produces_json_file(
@@ -653,7 +654,7 @@ class TestGenerateCommand:
                 "../../traversal-report.html",
             ],
         )
-        assert result.exit_code == 1
+        assert result.exit_code == ExitCode.CANNOT_RUN
 
 
 # ------------------------------------------------------------------
@@ -800,3 +801,174 @@ class TestInitCommand:
             os.chdir(original)
         assert result.exit_code == 0
         assert not (e2e_repo / ".mailmap").exists()
+
+
+# ------------------------------------------------------------------
+# Exit code contract
+# ------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestExitCodeContract:
+    """Tests for the documented exit code contract.
+
+    The distinction that matters to a CI consumer is between a negative
+    answer, which may be an acceptable state to record, and an inability
+    to answer, which is a broken pipeline step.
+    """
+
+    def test_codes_have_their_documented_values(self) -> None:
+        """The numbers are the contract; changing one breaks callers."""
+        assert ExitCode.SUCCESS == 0
+        assert ExitCode.NEGATIVE == 1
+        assert ExitCode.CANNOT_RUN == 2
+
+    def test_validate_succeeds_on_a_repository_with_commits(self, e2e_repo: Path) -> None:
+        result = CliRunner().invoke(app, ["validate", "--repo", str(e2e_repo)])
+        assert result.exit_code == ExitCode.SUCCESS
+
+    def test_validate_returns_negative_for_a_repository_with_no_commits(
+        self, tmp_path: Path
+    ) -> None:
+        """A readable repository with an unborn HEAD is a negative answer.
+
+        Distinct from a path that is not a repository at all, which is an
+        inability to answer. Separating these is the point of the contract.
+        """
+        empty = tmp_path / "empty_repo"
+        empty.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=empty, check=True, capture_output=True)
+        result = CliRunner().invoke(app, ["validate", "--repo", str(empty)])
+        assert result.exit_code == ExitCode.NEGATIVE
+
+    def test_validate_cannot_run_on_a_path_that_is_not_a_repository(self, tmp_path: Path) -> None:
+        plain = tmp_path / "not_a_repo"
+        plain.mkdir()
+        result = CliRunner().invoke(app, ["validate", "--repo", str(plain)])
+        assert result.exit_code == ExitCode.CANNOT_RUN
+
+    def test_the_two_failure_modes_are_distinguishable(self, tmp_path: Path) -> None:
+        """The finding this contract exists to resolve.
+
+        Before, 'not a repository' and 'repository has no commits' both
+        exited 1 and no CI job could tell them apart.
+        """
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=empty, check=True, capture_output=True)
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        runner = CliRunner()
+        no_commits = runner.invoke(app, ["validate", "--repo", str(empty)]).exit_code
+        not_a_repo = runner.invoke(app, ["validate", "--repo", str(plain)]).exit_code
+        assert no_commits != not_a_repo
+
+    def test_generate_returns_negative_for_an_empty_analysis_window(
+        self, e2e_repo: Path, tmp_path: Path
+    ) -> None:
+        """A window containing no commits is an answer, not a failure."""
+        result = CliRunner().invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(tmp_path / "report.html"),
+                "--since",
+                "1990-01-01",
+                "--until",
+                "1990-12-31",
+            ],
+        )
+        assert result.exit_code == ExitCode.NEGATIVE
+
+
+@pytest.mark.e2e
+class TestVerboseFlag:
+    """Tests for --verbose, which must be purely additive."""
+
+    def test_verbose_emits_diagnostics_to_stderr(self, e2e_repo: Path, tmp_path: Path) -> None:
+        result = CliRunner().invoke(
+            app,
+            [
+                "generate",
+                "--repo",
+                str(e2e_repo),
+                "--output",
+                str(tmp_path / "r.html"),
+                "--verbose",
+            ],
+        )
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "DEBUG" in result.output
+
+    def test_default_invocation_emits_no_diagnostics(self, e2e_repo: Path, tmp_path: Path) -> None:
+        """Adding the flag must not change output for anyone not using it."""
+        result = CliRunner().invoke(
+            app,
+            ["generate", "--repo", str(e2e_repo), "--output", str(tmp_path / "r.html")],
+        )
+        assert result.exit_code == ExitCode.SUCCESS
+        assert "DEBUG" not in result.output
+
+    def test_importing_reveille_installs_no_log_handler(self) -> None:
+        """A library must not impose logging policy on its host.
+
+        Run in a clean interpreter: a --verbose test elsewhere in this
+        process legitimately attaches a handler, so asserting in-process
+        would test the test suite rather than the import.
+        """
+        probe = (
+            "import logging, reveille; "
+            "print(all(isinstance(h, logging.NullHandler) "
+            "for h in logging.getLogger('reveille').handlers))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+        )
+        assert result.stdout.strip() == "True", result.stdout
+
+    def test_repeated_configuration_attaches_one_handler(self) -> None:
+        """Configuring twice must not duplicate every diagnostic line.
+
+        Asserted against the handler set rather than captured output:
+        `StreamHandler` binds `sys.stderr` at construction and CliRunner
+        replaces that stream per invocation, so an output-based assertion
+        would measure the test harness rather than the property.
+        """
+        import logging
+
+        from reveille.cli import _configure_logging
+
+        package_logger = logging.getLogger("reveille")
+        original_handlers = list(package_logger.handlers)
+        original_level = package_logger.level
+        try:
+            package_logger.handlers = [logging.NullHandler()]
+            _configure_logging(verbose=True)
+            _configure_logging(verbose=True)
+            attached = [
+                h
+                for h in package_logger.handlers
+                if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.NullHandler)
+            ]
+            assert len(attached) == 1
+        finally:
+            package_logger.handlers = original_handlers
+            package_logger.setLevel(original_level)
+
+    def test_configuring_without_verbose_attaches_nothing(self) -> None:
+        import logging
+
+        from reveille.cli import _configure_logging
+
+        package_logger = logging.getLogger("reveille")
+        original_handlers = list(package_logger.handlers)
+        try:
+            package_logger.handlers = [logging.NullHandler()]
+            _configure_logging(verbose=False)
+            assert all(isinstance(h, logging.NullHandler) for h in package_logger.handlers)
+        finally:
+            package_logger.handlers = original_handlers


### PR DESCRIPTION
### Summary
- Implemented grep/diff-style exit codes: 0 affirmative, 1 negative, 2 cannot run.
- Fixed bug: empty repository now returns negative answer, not cannot run.
- Added --verbose flag for generate/validate; logging idempotent and library-safe.

### Verification
- Ruff clean, mypy strict, all 9 pre-commit hooks pass.
- 291 tests passing (+11), coverage 93.61% (cli.py 93.18%).
- Verified downstream scripts: config and repo-access failures now return 2 where they returned 1.
- Logging tests confirm handler idempotency and NullHandler default.

### Notes
- Consumers should note: config/repo-access failures now return 2, not 1.
- Diagnostic detail remains on stderr; exit code range deliberately small.
- Next branch: fix/report-accessibility (#8).
