### PR TITLE
fix/report-accessibility: WCAG AA contrast and assistive-technology support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,37 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The muted text colour failed WCAG 2.1 AA contrast in both themes.** Light theme
+  measured 3.04:1 against the page background and 2.85:1 against raised surfaces — the
+  latter below even the 3:1 large-text threshold — and dark theme measured 4.12:1 and
+  3.77:1, against a 4.5:1 requirement for normal text. Both tokens are corrected
+  (`#8c959f` → `#69717a` light, `#6e7681` → `#7d8590` dark) and now clear AA on every
+  surface while remaining visibly lighter than secondary text, so the visual hierarchy is
+  unchanged. Contrast is now computed from the template's own CSS custom properties in
+  the test suite rather than checked by eye, so a future palette edit cannot silently
+  reintroduce the regression.
+
 ### Added
+
+- **The HTML report is now navigable with assistive technology.** It previously carried
+  no ARIA attributes, no table header scopes, and no text alternatives, which matters
+  because the report is explicitly built for stakeholder distribution — Confluence
+  embedding and email — the context in which WCAG 2.1 AA and EN 301 549 are asked about.
+  Specifically: every contributor-table column declares `scope="col"` and each rank cell
+  is a `scope="row"` header, so a screen reader announces which column a figure belongs
+  to; the table carries a caption naming the repository and analysis window; each of the
+  seven Plotly charts is exposed as a single labelled image with a described text
+  alternative, since SVG conveys nothing to a screen reader, and the alternatives point
+  at the contributor table that carries the same figures; the heatmap contributor filter
+  and year selector have accessible names, where the filter previously had none at all;
+  the year buttons expose their selected state through `aria-pressed`; summary cards
+  present the label and value as one phrase rather than two orphaned elements; the report
+  body is a `<main>` landmark; and `prefers-reduced-motion` is honoured per WCAG 2.1
+  SC 2.3.3.
+- The offline guarantee is now asserted in the test suite: no `<link>`, `<script>`, or
+  `<img>` in the rendered report may reference a remote host.
 
 - **Exit codes now distinguish a negative answer from an inability to run.** Every
   command returns `0` (success), `1` (Reveille ran and the repository state does not

--- a/src/reveille/templates/report.html.j2
+++ b/src/reveille/templates/report.html.j2
@@ -16,7 +16,7 @@
             --color-border-subtle:   #eaeef2;
             --color-text-primary:    #1c2128;
             --color-text-secondary:  #57606a;
-            --color-text-muted:      #8c959f;
+            --color-text-muted:      #69717a;
             --color-primary:         #1e40af;
             --color-primary-dim:     #dbeafe;
             --color-accent:          #2563eb;
@@ -43,7 +43,7 @@
             --color-border-subtle:   #21262d;
             --color-text-primary:    #e6edf3;
             --color-text-secondary:  #8b949e;
-            --color-text-muted:      #6e7681;
+            --color-text-muted:      #7d8590;
             --color-primary:         #58a6ff;
             --color-primary-dim:     #1f3458;
             --color-accent:          #79c0ff;
@@ -226,6 +226,37 @@
         /* ============================================================
            Chart Containers
            ============================================================ */
+        /* Accessible-but-invisible text: read by screen readers, never
+           painted. Uses the clip-path/1px technique rather than
+           display:none or visibility:hidden, both of which remove the
+           element from the accessibility tree entirely. */
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            margin: -1px;
+            padding: 0;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            clip-path: inset(50%);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        /* WCAG 2.1 SC 2.3.3. Readers who experience motion sickness or
+           vestibular disorders set this at the OS level; honour it by
+           removing transitions rather than merely shortening them. */
+        @media (prefers-reduced-motion: reduce) {
+            *,
+            *::before,
+            *::after {
+                transition-duration: 0.01ms !important;
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                scroll-behavior: auto !important;
+            }
+        }
+
         .chart-container {
             padding: 16px 16px 8px;
             background: var(--color-surface-raised);
@@ -487,7 +518,7 @@
     </style>
 </head>
 <body>
-<div class="page">
+<main class="page">
 
     <!-- ============================================================
          Header
@@ -518,30 +549,42 @@
          ============================================================ -->
     <div class="summary-grid">
         <div class="summary-card">
-            <div class="value">{{ data.metadata.total_commits }}</div>
-            <div class="label">Total Commits</div>
+            <span class="visually-hidden">Total Commits: {{ data.metadata.total_commits }}</span>
+            <div class="value" aria-hidden="true">{{ data.metadata.total_commits }}</div>
+            <div class="label" aria-hidden="true">Total Commits</div>
         </div>
         <div class="summary-card">
-            <div class="value">{{ data.metadata.unique_contributors }}</div>
-            <div class="label">Contributors</div>
+            <span class="visually-hidden">Contributors: {{ data.metadata.unique_contributors }}</span>
+            <div class="value" aria-hidden="true">{{ data.metadata.unique_contributors }}</div>
+            <div class="label" aria-hidden="true">Contributors</div>
         </div>
         <div class="summary-card">
-            <div class="value">{{ derived.commit_concentration }}</div>
-            <div class="label">Commit Concentration</div>
+            <span class="visually-hidden">Commit Concentration: {{ derived.commit_concentration }}</span>
+            <div class="value" aria-hidden="true">{{ derived.commit_concentration }}</div>
+            <div class="label" aria-hidden="true">Commit Concentration</div>
         </div>
         <div class="summary-card">
-            <div class="value">{{ derived.longest_inactive_streak }}</div>
-            <div class="label">Max Inactive Days</div>
+            <span class="visually-hidden">Max Inactive Days: {{ derived.longest_inactive_streak }}</span>
+            <div class="value" aria-hidden="true">{{ derived.longest_inactive_streak }}</div>
+            <div class="label" aria-hidden="true">Max Inactive Days</div>
         </div>
         <div class="summary-card">
-            <div class="value">
+            <span class="visually-hidden">
+                Top Contributor:
+                {% if data.ranked_contributors %}
+                    {{ data.ranked_contributors[0].stats.name }}
+                {% else %}
+                    none
+                {% endif %}
+            </span>
+            <div class="value" aria-hidden="true">
                 {% if data.ranked_contributors %}
                     {{ data.ranked_contributors[0].stats.name.split()[0] }}
                 {% else %}
                     --
                 {% endif %}
             </div>
-            <div class="label">Top Contributor</div>
+            <div class="label" aria-hidden="true">Top Contributor</div>
         </div>
     </div>
 
@@ -551,12 +594,14 @@
     <div class="section">
         <h2 class="section-title">Commit Activity Heatmap</h2>
         <div class="heatmap-controls">
-            <div id="heatmap-year-tabs" class="heatmap-year-tabs"></div>
+            <div id="heatmap-year-tabs" class="heatmap-year-tabs"
+                 role="group" aria-label="Select calendar year for the heatmap"></div>
             <select id="heatmap-contributor-select"
-                    class="heatmap-contributor-select"></select>
+                    class="heatmap-contributor-select"
+                    aria-label="Filter the activity heatmap by contributor"></select>
         </div>
         <div class="chart-container">
-            <div id="chart-heatmap"></div>
+            <div id="chart-heatmap" role="img" aria-label="Activity heatmap: commit counts per calendar day. The same activity is summarised per contributor in the Contributor Rankings table."></div>
         </div>
     </div>
 
@@ -566,7 +611,7 @@
     <div class="section">
         <h2 class="section-title">Weekly Commit Timeline</h2>
         <div class="chart-container">
-            <div id="chart-timeline"></div>
+            <div id="chart-timeline" role="img" aria-label="Line chart of total commits per calendar week across the analysis window."></div>
         </div>
     </div>
 
@@ -576,7 +621,7 @@
     <div class="section">
         <h2 class="section-title">Per-Contributor Commit Frequency</h2>
         <div class="chart-container">
-            <div id="chart-contributor_timeline"></div>
+            <div id="chart-contributor_timeline" role="img" aria-label="Line chart of commits per calendar week, one line per contributor."></div>
         </div>
     </div>
 
@@ -588,26 +633,32 @@
         <h2 class="section-title">Contributor Rankings</h2>
         <div class="table-wrapper">
             <table class="ranking-table">
+                <caption class="visually-hidden">
+                    Contributor rankings for {{ data.metadata.name }} between
+                    {{ data.metadata.analysis_since }} and {{ data.metadata.analysis_until }}.
+                    One row per contributor, ordered by composite score. This table
+                    carries the same underlying data as the charts on this page.
+                </caption>
                 <thead>
                     <tr>
-                        <th style="text-align:center; width:44px">#</th>
-                        <th style="min-width:160px">Contributor</th>
-                        <th style="min-width:140px">Designation</th>
-                        <th style="text-align:right">Commits</th>
-                        <th style="text-align:right">Lines Added</th>
-                        <th style="text-align:right">Lines Deleted</th>
-                        <th style="text-align:right">Net Lines</th>
-                        <th style="text-align:right">Active Days</th>
-                        <th style="white-space:nowrap">Last Commit</th>
-                        <th style="min-width:180px">Score</th>
+                        <th scope="col" style="text-align:center; width:44px">#</th>
+                        <th scope="col" style="min-width:160px">Contributor</th>
+                        <th scope="col" style="min-width:140px">Designation</th>
+                        <th scope="col" style="text-align:right">Commits</th>
+                        <th scope="col" style="text-align:right">Lines Added</th>
+                        <th scope="col" style="text-align:right">Lines Deleted</th>
+                        <th scope="col" style="text-align:right">Net Lines</th>
+                        <th scope="col" style="text-align:right">Active Days</th>
+                        <th scope="col" style="white-space:nowrap">Last Commit</th>
+                        <th scope="col" style="min-width:180px">Score</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for contributor in data.ranked_contributors %}
                     <tr>
-                        <td class="rank-number" style="text-align:center">
+                        <th scope="row" class="rank-number" style="text-align:center">
                             {{ loop.index }}
-                        </td>
+                        </th>
                         <td>
                             <span class="contributor-name">
                                 {{ contributor.stats.name }}
@@ -684,22 +735,22 @@
         <div class="chart-row">
             <div class="chart-container">
                 <p class="chart-label">Commits by Contributor</p>
-                <div id="chart-contributor_commits"></div>
+                <div id="chart-contributor_commits" role="img" aria-label="Bar chart of total commits per contributor. The same figures appear in the Commits column of the Contributor Rankings table."></div>
             </div>
             <div class="chart-container">
                 <p class="chart-label">Lines Changed by Contributor</p>
-                <div id="chart-contributor_lines"></div>
+                <div id="chart-contributor_lines" role="img" aria-label="Bar chart of lines changed per contributor. The same figures appear in the Lines Added and Lines Deleted columns of the Contributor Rankings table."></div>
             </div>
         </div>
 
         <div class="chart-row">
             <div class="chart-container">
                 <p class="chart-label">Commit Share</p>
-                <div id="chart-pie_commits"></div>
+                <div id="chart-pie_commits" role="img" aria-label="Donut chart of each contributor's share of total commits."></div>
             </div>
             <div class="chart-container">
                 <p class="chart-label">Lines Changed Share</p>
-                <div id="chart-pie_lines"></div>
+                <div id="chart-pie_lines" role="img" aria-label="Donut chart of each contributor's share of total lines changed."></div>
             </div>
         </div>
     </div>
@@ -714,7 +765,7 @@
         </span>
     </footer>
 
-</div>
+</main>
 
 <!-- ================================================================
      Plotly JS bundle — self-contained, no CDN
@@ -1027,14 +1078,16 @@
                 btn.textContent = String(yr);
                 btn.className = 'heatmap-year-btn' +
                     (yr === currentYear ? ' heatmap-year-active' : '');
+                // Communicates the selected year to assistive technology,
+                // which cannot infer it from the active-state class alone.
+                btn.setAttribute('aria-pressed', yr === currentYear ? 'true' : 'false');
                 btn.addEventListener('click', function () {
                     currentYear = yr;
                     tabsEl.querySelectorAll('.heatmap-year-btn')
                         .forEach(function (b) {
-                            b.classList.toggle(
-                                'heatmap-year-active',
-                                b.textContent === String(yr)
-                            );
+                            var selected = b.textContent === String(yr);
+                            b.classList.toggle('heatmap-year-active', selected);
+                            b.setAttribute('aria-pressed', selected ? 'true' : 'false');
                         });
                     renderHeatmap(currentYear, currentContributor, readTheme());
                 });

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -16,6 +16,7 @@ for tests that only inspect default output structure.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -972,3 +973,74 @@ class TestVerboseFlag:
             assert all(isinstance(h, logging.NullHandler) for h in package_logger.handlers)
         finally:
             package_logger.handlers = original_handlers
+
+
+# ------------------------------------------------------------------
+# Report accessibility
+# ------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestReportAccessibility:
+    """Structural accessibility assertions on the rendered report.
+
+    The report is distributed to stakeholders and embedded in Confluence,
+    which is the context where WCAG 2.1 AA and EN 301 549 are asked about.
+    These assert the structures assistive technology depends on survive
+    into the output.
+    """
+
+    def test_document_declares_a_language(self, default_report_content: str) -> None:
+        assert 'lang="en"' in default_report_content
+
+    def test_report_body_is_a_main_landmark(self, default_report_content: str) -> None:
+        """Lets a screen-reader user skip navigation straight to content."""
+        assert "<main" in default_report_content
+
+    def test_table_column_headers_declare_scope(self, default_report_content: str) -> None:
+        """Without scope, a screen reader cannot announce which column a cell belongs to."""
+        assert default_report_content.count('scope="col"') >= 10
+
+    def test_table_row_headers_declare_scope(self, default_report_content: str) -> None:
+        assert 'scope="row"' in default_report_content
+
+    def test_table_has_a_caption(self, default_report_content: str) -> None:
+        """The caption names the table when navigating between tables."""
+        assert "<caption" in default_report_content
+
+    def test_every_chart_has_a_text_alternative(self, default_report_content: str) -> None:
+        """Plotly renders to SVG, which conveys nothing to assistive technology.
+
+        Each chart container is exposed as a single labelled image rather
+        than a tree of meaningless shapes.
+        """
+        assert default_report_content.count('role="img"') >= 7
+
+    def test_heatmap_contributor_filter_is_labelled(self, default_report_content: str) -> None:
+        """A bare select announces only its value, never its purpose."""
+        assert "Filter the activity heatmap by contributor" in default_report_content
+
+    def test_summary_cards_expose_a_coherent_phrase(self, default_report_content: str) -> None:
+        """The value and its label are separate elements visually.
+
+        Read literally, that gives a screen reader an orphaned number
+        followed by an orphaned noun. The visually hidden text restores
+        the association.
+        """
+        assert "visually-hidden" in default_report_content
+        assert "Total Commits:" in default_report_content
+
+    def test_reduced_motion_preference_is_honoured(self, default_report_content: str) -> None:
+        """WCAG 2.1 SC 2.3.3, set at the OS level by affected readers."""
+        assert "prefers-reduced-motion" in default_report_content
+
+    def test_report_still_loads_no_external_resources(self, default_report_content: str) -> None:
+        """The offline guarantee must survive every accessibility change.
+
+        No stylesheet link, script src, or image src may reference a
+        remote host. Attribution URLs inside the vendored Plotly bundle
+        are inert string literals for chart types Reveille never renders.
+        """
+        assert not re.search(r"<link[^>]+href=\"https?://", default_report_content)
+        assert not re.search(r"<script[^>]+src=\"https?://", default_report_content)
+        assert not re.search(r"<img[^>]+src=\"https?://", default_report_content)

--- a/tests/unit/adapters/test_report_contrast.py
+++ b/tests/unit/adapters/test_report_contrast.py
@@ -1,0 +1,105 @@
+"""Colour contrast tests for the report template.
+
+The report is distributed to stakeholders — embedded in Confluence, sent
+by email — which is the context where accessibility is asked about. Both
+themes must meet WCAG 2.1 AA for text.
+
+Contrast is computed from the CSS custom properties declared in the
+template rather than asserted against a copy of them, so a token edited
+in the template is checked here without anyone remembering to update a
+fixture. The muted token failed AA in both themes until v0.7.0.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import reveille
+
+_TEMPLATE = Path(reveille.__file__).parent / "templates" / "report.html.j2"
+
+# WCAG 2.1 SC 1.4.3 (Contrast Minimum), AA, normal-size text.
+_AA_NORMAL_TEXT = 4.5
+
+
+def _relative_luminance(hex_colour: str) -> float:
+    """Compute relative luminance per WCAG 2.1 definition.
+
+    Args:
+        hex_colour: A colour in `#rrggbb` form.
+
+    Returns:
+        Relative luminance in the range [0, 1].
+    """
+    channels = [int(hex_colour[i : i + 2], 16) / 255 for i in (1, 3, 5)]
+    linear = [c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in channels]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(foreground: str, background: str) -> float:
+    """Compute the WCAG contrast ratio between two colours.
+
+    Args:
+        foreground: Text colour in `#rrggbb` form.
+        background: Background colour in `#rrggbb` form.
+
+    Returns:
+        The ratio, between 1.0 (identical) and 21.0 (black on white).
+    """
+    a, b = _relative_luminance(foreground), _relative_luminance(background)
+    lighter, darker = max(a, b), min(a, b)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _tokens_for(theme: str) -> dict[str, str]:
+    """Extract the CSS custom properties declared for one theme.
+
+    Args:
+        theme: Either "light" or "dark".
+
+    Returns:
+        A mapping of custom-property name to `#rrggbb` value.
+    """
+    source = _TEMPLATE.read_text(encoding="utf-8")
+    selector = r":root\s*\{" if theme == "light" else r'\[data-theme="dark"\]\s*\{'
+    match = re.search(selector + r"(.*?)\}", source, re.DOTALL)
+    assert match is not None, f"no {theme} theme block found in the template"
+    return dict(re.findall(r"(--color-[\w-]+):\s*(#[0-9a-fA-F]{6});", match.group(1)))
+
+
+# Every foreground token that renders text, against both surfaces it can sit on.
+_TEXT_TOKENS = ["--color-text-primary", "--color-text-secondary", "--color-text-muted"]
+_BACKGROUNDS = ["--color-bg", "--color-surface"]
+
+
+@pytest.mark.unit
+class TestThemeContrast:
+    """Tests for WCAG AA text contrast in both report themes."""
+
+    @pytest.mark.parametrize("theme", ["light", "dark"])
+    @pytest.mark.parametrize("foreground", _TEXT_TOKENS)
+    @pytest.mark.parametrize("background", _BACKGROUNDS)
+    def test_text_meets_aa_contrast(self, theme: str, foreground: str, background: str) -> None:
+        tokens = _tokens_for(theme)
+        ratio = _contrast_ratio(tokens[foreground], tokens[background])
+        assert ratio >= _AA_NORMAL_TEXT, (
+            f"{theme}: {foreground} ({tokens[foreground]}) on {background} "
+            f"({tokens[background]}) is {ratio:.2f}:1, below AA {_AA_NORMAL_TEXT}:1"
+        )
+
+    @pytest.mark.parametrize("theme", ["light", "dark"])
+    def test_muted_stays_visually_below_secondary(self, theme: str) -> None:
+        """Raising contrast must not flatten the visual hierarchy.
+
+        Muted text exists to recede. If a contrast fix pushed it to the
+        same weight as secondary text, the fix would have destroyed the
+        distinction it was meant to preserve.
+        """
+        tokens = _tokens_for(theme)
+        background = tokens["--color-surface"]
+        muted = _contrast_ratio(tokens["--color-text-muted"], background)
+        secondary = _contrast_ratio(tokens["--color-text-secondary"], background)
+        assert muted < secondary


### PR DESCRIPTION
### Summary
- Corrected muted text contrast; now passes WCAG AA in both light and dark themes.
- Structural accessibility added: table scopes, chart alt text, labelled controls, aria states, unified summary cards.
- Added <main> landmark and prefers-reduced-motion support.
- Verified offline moat: no remote resources referenced in rendered report.

### Verification
- make ci green: 315 tests (+24), all pre-commit hooks pass.
- Contrast test parses tokens directly; restoring old values fails tests.
- Mutation-checked: guards fail when removed.
- Offline moat test ensures no external resources fetched.

### Notes
- Boundary: structural conformance verified by computation and assertion; not yet manually audited with screen reader. Worth one NVDA/VoiceOver pass before claiming AA publicly.
- Next branch: chore/supply-chain-evidence (#9, #12).
