### PR TITLE
docs/architecture-record: ship the architecture contract and decision records

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+# ==================================================================
+# Reveille -- editor defaults
+#
+# Deliberately narrow. This file exists to stop an editor fighting the
+# formatter over whitespace, not to restate the style guide. Formatting
+# is owned by ruff (`make format`); anything ruff decides is not
+# duplicated here, because two sources for one rule drift apart.
+#
+# https://editorconfig.org
+# ==================================================================
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_size = 4
+# Matches `line-length = 100` in pyproject.toml [tool.ruff].
+max_line_length = 100
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.{html,j2,css,js}]
+indent_size = 2
+
+[*.md]
+indent_size = 2
+# Two trailing spaces are a hard line break in Markdown. Stripping them
+# silently reflows paragraphs.
+trim_trailing_whitespace = false
+
+# Tabs are syntax in a Makefile, not indentation. A recipe line that
+# loses its tab stops working.
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,77 @@
+# ==================================================================
+# Reveille -- Git attributes
+#
+# The entry with real teeth is the first one. Without it, a checkout on
+# Windows and a checkout on Linux produce different bytes for the same
+# commit, and every cross-platform contributor generates whole-file
+# diffs that bury the actual change.
+# ==================================================================
+
+# Normalise all text to LF in the repository, regardless of platform.
+# Git detects which files are text; the explicit entries below override
+# that detection where guessing wrong would be costly.
+* text=auto eol=lf
+
+# ------------------------------------------------------------------
+# Explicitly text
+# ------------------------------------------------------------------
+
+*.py        text diff=python
+*.pyi       text diff=python
+*.j2        text
+*.md        text diff=markdown
+*.toml      text
+*.yml       text
+*.yaml      text
+*.json      text
+*.cfg       text
+*.ini       text
+*.txt       text
+*.html      text diff=html
+*.css       text diff=css
+*.js        text
+.gitignore  text
+.gitattributes text
+.editorconfig  text
+Makefile    text
+
+# Shell scripts must keep LF even if a tool is configured otherwise --
+# CRLF makes them unexecutable.
+*.sh        text eol=lf
+
+# ------------------------------------------------------------------
+# Explicitly binary -- never normalise, never diff
+# ------------------------------------------------------------------
+
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.pdf       binary
+*.woff      binary
+*.woff2     binary
+*.gz        binary
+*.zip       binary
+*.whl       binary
+
+# ------------------------------------------------------------------
+# Language statistics
+#
+# The repository is Python. Without these, the vendored Plotly bundle in
+# generated reports and the report template's inline CSS/JS would have
+# GitHub reporting this as a JavaScript project.
+# ------------------------------------------------------------------
+
+*.j2                    linguist-language=HTML
+docs/**                 linguist-documentation
+tests/**                linguist-language=Python
+
+# ------------------------------------------------------------------
+# Excluded from source archives (`git archive`)
+# ------------------------------------------------------------------
+
+.github/        export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+tests/          export-ignore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# ==================================================================
+# Reveille -- code owners
+#
+# Every pull request requests review from the owner of each path it
+# touches. Reveille currently has a single maintainer, so the catch-all
+# covers everything; the explicit entries below exist to make the
+# high-consequence paths visible rather than to route them elsewhere.
+#
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# ==================================================================
+
+# Default owner for everything in the repository.
+*                       @varaprasadchilakanti
+
+# ------------------------------------------------------------------
+# Release and supply chain
+#
+# These paths decide what gets published and under whose identity. A
+# change here is a change to the trust boundary, not to a feature.
+# ------------------------------------------------------------------
+
+/.github/workflows/     @varaprasadchilakanti
+/SECURITY.md            @varaprasadchilakanti
+/pyproject.toml         @varaprasadchilakanti
+/poetry.lock            @varaprasadchilakanti
+
+# ------------------------------------------------------------------
+# Architectural contracts
+#
+# The layering rules and the decisions that justify them. Changing these
+# documents without changing the code -- or the reverse -- is drift.
+# ------------------------------------------------------------------
+
+/docs/ARCHITECTURE.md   @varaprasadchilakanti
+/docs/adr/              @varaprasadchilakanti

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ### Added
 
+- **`docs/ARCHITECTURE.md` documents how Reveille is built.** The architecture record
+  previously existed only in a gitignored working file, so a contributor cloning the
+  repository could not read the layering contract they were expected to honour. It covers
+  the dependency rule and framework ownership, the domain model, the error model and exit
+  codes, the analysis pipeline, identity resolution, ranking, and the invariants the test
+  suite exists to protect. It was rewritten against the source rather than copied: the
+  prior record was pinned at v0.5.0 and predated the exception rename, JSON and CSV
+  export, `ProgressEvent`, exit codes, the single-pass history read, and the commit
+  concentration rename.
+
+- **`docs/adr/` records six decisions with their reasoning** — unconditional merge-commit
+  exclusion, email as the identity key, lower-bound percentile ranking, the single-pass
+  `--numstat` read, commit concentration over "bus factor", and the offline single-file
+  report. Each states what the decision costs and what it rules out, so a future reversal
+  argues with the original reasoning rather than reconstructing it.
+
+- **A layering test enforces the dependency rule.** `tests/unit/test_layering.py` imports
+  each layer in a clean interpreter and asserts which frameworks reach `sys.modules`. A
+  contract that lives only in a document erodes one convenient import at a time with
+  nothing failing; this one fails the suite.
+
+- **A documentation link test** asserts that every relative link between repository
+  documents resolves, and that no ADR is missing from its index. Cross-references rot
+  silently — a renamed file leaves a link that still reads correctly and 404s.
+
+- **`.gitattributes`, `.editorconfig`, `.github/CODEOWNERS`, and `CODE_OF_CONDUCT.md`.**
+  The consequential one is `* text=auto eol=lf`: without it, checkouts on different
+  platforms produce different bytes for the same commit and cross-platform contributors
+  generate whole-file diffs that bury the actual change. No tracked file currently
+  contains CRLF, so adding it produces no renormalisation diff. `.editorconfig` is
+  deliberately narrow and defers all formatting to ruff rather than restating it.
+
 - **Every tagged release now generates a CycloneDX 1.6 SBOM.** The bill of materials
   covers the runtime dependency graph resolved from `poetry.lock`; development and test
   dependencies are excluded, because they describe how Reveille is built rather than what
@@ -37,6 +69,14 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   seam in the release path.
 
 ### Changed
+
+- **`CONTRIBUTING.md` no longer claims the domain layer has no framework imports.** It
+  does have one: `domain/ranking.py` imports `RankingWeights` from `config.py`, which is a
+  Pydantic model. This is a deliberate trade — the alternative is two definitions of the
+  same four weights that can drift — but the document stated the stronger claim, and a
+  contributor checking it against the source would have found the document wrong. The rule
+  is now stated as what it actually protects: the domain performs no I/O and no rendering.
+  `tests/unit/test_layering.py` enforces that version.
 
 - **Action pin comments now name exact versions.** Four pins were labelled with moving
   aliases — `# release/v1` on `pypa/gh-action-pypi-publish`, `# v1` on

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**varaprasadchilakanti@gmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+Note that Reveille is maintained by one person, who is therefore also the
+person who receives reports. If a report concerns the maintainer, or you would
+rather not raise it directly, GitHub's own reporting route is available at
+<https://github.com/contact/report-abuse>.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/inclusion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,21 +73,34 @@ exclusion rather than a blanket ceiling.
 
 ## Architecture
 
-Reveille follows Clean Architecture strictly. The dependency rule is
-absolute: outer layers depend on inner layers, never the reverse.
+**Read [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) before your first
+change.** It describes the layering contract, the domain model, the
+pipeline, and the invariants that tests exist to protect. Individual
+decisions and their reasoning live in [docs/adr/](docs/adr/).
 
-- `src/reveille/domain/` — pure Python dataclasses and the ranking
-  engine. No framework imports, no I/O.
-- `src/reveille/adapters/` — `GitReader` (the only layer that imports
-  GitPython) and `Renderer` (the only layer that imports Jinja2 and
+In short: dependencies point inward, and outer layers never appear in
+inner ones.
+
+- `src/reveille/domain/` — frozen dataclasses and the ranking engine.
+  Performs no I/O and no rendering. It does import `RankingWeights` from
+  `config.py`, which is a Pydantic model; that is a deliberate,
+  documented exception rather than a leak.
+- `src/reveille/adapters/` — `GitReader` (the only module that imports
+  GitPython) and `Renderer` (the only module that imports Jinja2 and
   Plotly).
-- `src/reveille/services/` — the `generate_report` orchestrator.
-  No knowledge of infrastructure libraries.
-- `src/reveille/cli.py` — argument parsing and progress display only.
-  No business logic.
+- `src/reveille/services/` — the `generate_report` orchestrator. Emits
+  `ProgressEvent`; knows nothing about terminals.
+- `src/reveille/cli.py` — the only module that imports Typer. Argument
+  parsing, exit codes, and progress display. No business logic.
 
 New behaviour belongs in the layer that owns its concern. Domain logic
-that acquires a framework import is a layering violation.
+that acquires an I/O or presentation import is a layering violation, and
+`tests/unit/test_layering.py` will fail rather than leave it to review.
+
+If a change makes a statement in `ARCHITECTURE.md` untrue, update the
+document in the same pull request. An architecture document that
+describes an intended design rather than the built one is worse than
+none.
 
 ## Submitting Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,13 @@ annotated examples, the ranking algorithm in plain language, how to interpret
 each section of the generated report, and practical patterns for common use
 cases.
 
+For how Reveille is built rather than how it is used, see
+[docs/ARCHITECTURE.md](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/ARCHITECTURE.md)
+— the layering contract, the domain model, the analysis pipeline, and the
+invariants the test suite protects. Individual design decisions and the
+reasoning behind them are recorded in
+[docs/adr/](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/adr/).
+
 ---
 
 ## Development Setup
@@ -344,6 +351,8 @@ ruff check src/
 ## Contributing
 
 Contributions are welcome. Please read [CONTRIBUTING.md](https://github.com/varaprasadchilakanti/reveille/blob/main/CONTRIBUTING.md) before opening a pull request. It covers the development environment setup, architecture overview, pull request contract, code style requirements, and commit message conventions.
+
+Participation is governed by the [Code of Conduct](https://github.com/varaprasadchilakanti/reveille/blob/main/CODE_OF_CONDUCT.md).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,377 @@
+# Architecture
+
+This document describes how Reveille is built and, more importantly,
+*why* it is built that way. It is written for someone about to change the
+code.
+
+It describes the system **as it exists**, not as it was once intended.
+Every claim here was checked against the source when written. If you
+find a statement that no longer holds, the statement is the bug — fix it
+in the same pull request as the code that outdated it.
+
+For how to *use* Reveille, see [USER_GUIDE.md](USER_GUIDE.md). For
+individual decisions and the reasoning behind them, see
+[adr/](adr/).
+
+---
+
+## What Reveille is
+
+A command-line tool that reads a local Git repository and writes a
+single self-contained HTML file describing its contribution history.
+
+Three properties constrain nearly every design decision, and are worth
+stating before anything else:
+
+**It is read-only.** Reveille opens a repository, reads history, and
+writes one output file at a path you name. It never writes to `.git`,
+never creates commits or branches, and never runs a mutating Git
+command. Anything that would change repository state is out of scope by
+construction, not by omission.
+
+**It is offline.** Nothing is transmitted anywhere. The generated report
+loads no CDN, no web font, and no remote image — the ~3.5 MB Plotly
+bundle is embedded in the file itself. This is what makes the output
+safe to attach to an email or embed in Confluence, and it is enforced by
+a test asserting no `<link>`, `<script>`, or `<img>` in the template
+references a remote host.
+
+**It is a single file.** The report is one HTML document with no
+sidecar assets. A stakeholder can open it from a download folder on a
+machine with no network connection.
+
+These are not incidental. A change that breaks any of the three is a
+change to what the product *is*, and needs to be argued as such.
+
+---
+
+## The dependency rule
+
+```
+  cli.py  ─────►  services/  ─────►  domain/  ◄─────  adapters/
+                                        ▲
+                                        │
+                                    config.py
+```
+
+Dependencies point inward. The domain knows nothing about how commits
+are read or how reports are drawn.
+
+| Layer | May import | Must not import |
+|---|---|---|
+| `domain/` | stdlib, `config.py` | GitPython, Plotly, Jinja2, Typer |
+| `adapters/` | stdlib, `domain/`, its own framework | `services/`, `cli.py` |
+| `services/` | `domain/`, `adapters/`, `config.py` | Typer, GitPython, Plotly, Jinja2 |
+| `cli.py` | `services/`, `config.py`, `exceptions.py` | GitPython, Plotly, Jinja2 |
+
+Framework ownership is exclusive, and deliberately so:
+
+- `adapters/git_reader.py` is the **only** module that imports GitPython.
+- `adapters/renderer.py` is the **only** module that imports Plotly or Jinja2.
+- `cli.py` is the **only** module that imports Typer.
+
+The point is substitutability. Reading history from a different source,
+or rendering to a different format, means writing one new adapter — not
+tracing framework calls through the codebase.
+
+`tests/unit/test_layering.py` enforces this by importing each layer in a
+clean interpreter and asserting which frameworks appear in
+`sys.modules`. A layering violation fails the suite rather than being
+noticed in review, or not noticed.
+
+### One honest exception
+
+`domain/ranking.py` imports `RankingWeights` from `config.py`, which is
+a Pydantic model. So the domain is not literally free of third-party
+imports — it transitively imports Pydantic.
+
+This is a deliberate trade, not an oversight. `RankingWeights` is a
+value object whose only behaviour is validating that four weights sum to
+1.0, and Pydantic is the project's validation library. Duplicating it as
+a plain dataclass would mean two definitions of the same concept that
+can drift apart.
+
+What the rule actually protects is stated precisely: **the domain
+imports no I/O and no presentation framework.** It reads nothing,
+writes nothing, and draws nothing. That is the property that makes the
+ranking engine testable without a repository on disk, and it holds.
+
+---
+
+## Module map
+
+```
+src/reveille/
+    __init__.py       __version__; installs a logging NullHandler
+    cli.py            Typer app, exit codes, progress display
+    config.py         Pydantic config models and TOML loading
+    init.py           reveille.toml and .mailmap scaffold generation
+    exceptions.py     the exception hierarchy
+    py.typed          PEP 561 marker — this package ships type information
+    domain/
+        models.py     frozen dataclasses; no behaviour beyond derived properties
+        ranking.py    the scoring and tiering algorithm
+    adapters/
+        git_reader.py GitPython in; domain models out
+        renderer.py   domain models in; HTML, JSON, or CSV out
+    services/
+        report.py     generate_report — the pipeline
+    templates/
+        report.html.j2
+```
+
+---
+
+## Domain model
+
+All frozen dataclasses in `domain/models.py`. They carry data and
+derived properties, never I/O.
+
+**`Commit`** — `sha`, `author_name`, `author_email`, `timestamp`,
+`lines_added`, `lines_deleted`. Property: `lines_changed`.
+
+**`ContributorStats`** — `name`, `email`, `commit_count`,
+`lines_added`, `lines_deleted`, `active_days`, `first_commit_date`,
+`last_commit_date`. Properties: `net_lines`, `lines_changed`.
+
+**`RankedContributor`** — wraps `stats` with `composite_score`,
+`percentile`, `tier`, `tier_designation`.
+
+**`RepositoryMetadata`** — `name`, `remote_url`, `default_branch`,
+`total_commits`, `unique_contributors`, `analysis_since`,
+`analysis_until`, `generated_at`.
+
+**`ProgressEvent`** — `stage`, `elapsed_seconds`, `items_processed`.
+The service emits these; the CLI decides whether to animate them, log
+them, or ignore them. The service has no opinion about terminals.
+
+**`ReportData`** — `metadata`, `ranked_contributors`, `commits`. The
+sole input to `Renderer`.
+
+---
+
+## Error model
+
+```
+ReveilleError
+├── RepositoryError
+│   └── EmptyRepositoryError
+├── ConfigurationError
+└── RenderError
+    └── OutputPathError
+```
+
+Everything Reveille raises across a layer boundary descends from
+`ReveilleError`, so the CLI can catch one type and be sure nothing
+escapes as a traceback. Adapters raise the specific subclass; the CLI
+maps it to an exit code.
+
+`RevelleError` — the original misspelling — remains available as a
+deprecated alias via a module-level `__getattr__` (PEP 562). It emits a
+`DeprecationWarning` and is scheduled for removal in v1.0.0. It is
+absent from `__all__`.
+
+### Exit codes
+
+`cli.ExitCode` is part of the public contract:
+
+| Code | Meaning |
+|---|---|
+| `0` `SUCCESS` | Ran; answer affirmative. |
+| `1` `NEGATIVE` | Ran correctly; answer negative — an analysis window with no commits. |
+| `2` `CANNOT_RUN` | Could not run: bad invocation, bad config, unreadable repository, unwritable output. |
+
+The split follows `grep` and `diff`, distinguishing *a negative answer*
+from *an inability to answer*. That is the distinction a CI job acts on:
+an empty window may be an acceptable state to record; an unreadable
+repository is a broken pipeline step. Finer causes belong in the stderr
+message — encoding each one as its own code does not scale, and every
+addition would break callers branching on the old numbering.
+
+---
+
+## The pipeline
+
+`services/report.py::generate_report(config, on_progress=None)` runs
+four stages, emitting a `ProgressEvent` before each:
+
+1. **Reading commit history** — `GitReader.read_commits`
+2. **Aggregating contributor statistics** — `GitReader.aggregate_contributor_stats`
+3. **Ranking contributors** — `domain.ranking.rank_contributors`
+4. **Rendering report** — `Renderer.render` / `render_json` / `render_csv`
+
+With `ranking_enabled=False`, stage 3 still produces
+`RankedContributor` objects, with `tier=0`, designation `"--"`, and
+score and percentile zeroed. The shape stays constant so the renderer
+has no branch for it.
+
+### Reading history
+
+`read_commits` runs a single `git log --numstat` and parses the output,
+rather than iterating commits and asking GitPython for per-commit
+stats. The reason is that `Commit.stats` shells out to `git diff` once
+per commit; the single-pass read measured **9.4× faster** on this
+repository (7.2 ms/commit → 0.77 ms/commit), which is the difference
+between roughly six minutes and forty seconds on a 50,000-commit
+repository. Output was verified byte-identical against the previous
+implementation before the change landed. See
+[ADR-0004](adr/0004-single-pass-numstat-read.md).
+
+Merge commits are excluded unconditionally — see
+[ADR-0001](adr/0001-exclude-merge-commits.md).
+
+An unborn `HEAD` — a repository that is readable but has no commits at
+all — raises `EmptyRepositoryError`, which the CLI maps to `NEGATIVE`.
+It is a negative answer, not a failure to read.
+
+### Identity resolution
+
+Contributors are keyed on lowercased email — see
+[ADR-0002](adr/0002-email-as-identity-key.md). Two normalisations run
+before that key is taken:
+
+**`.mailmap`**, all four forms from `gitmailmap(5)`, matched
+most-specific-first: name-and-email → email-only → name-only. Matching
+is case-insensitive. Malformed lines are skipped silently, matching
+Git's own behaviour.
+
+**GitHub noreply addresses.** Both the legacy
+`username@users.noreply.github.com` and the post-2017
+`12345678+username@users.noreply.github.com` forms exist, and the same
+person often appears under both. The numeric prefix is stripped so they
+fold together.
+
+### Rendering
+
+`_build_charts` returns a dict keyed `timeline`,
+`contributor_timeline`, `heatmap`, `contributor_commits`,
+`contributor_lines`, `pie_commits`, `pie_lines`. Each value is a Plotly
+JSON string, or the string `"null"` when there is nothing to draw —
+the template checks for that sentinel rather than the renderer deciding
+what the page looks like.
+
+The heatmap is the exception: it ships a compact daily-count payload,
+not a Plotly figure, and client-side JavaScript builds the Mon–Sun grid.
+A per-day Plotly spec for a multi-year repository is far larger than the
+counts it encodes.
+
+Everything written into a `<script>` block has `</` escaped to `<\/`.
+Without it, a contributor whose name contains `</script>` closes the
+block and executes the remainder as markup. `_sanitise_chart_label`
+strips HTML tags from labels for the same reason. Jinja autoescaping is
+on (`select_autoescape(["html", "j2"])`), but it does not apply inside a
+JSON script block — that is why the escaping is explicit.
+
+`_to_json` strips `paper_bgcolor`, `plot_bgcolor`, and `font.color`
+from the serialised layout. Theme colours are injected client-side via
+`Plotly.relayout()` when the toggle flips, so the charts recolour
+without a re-render.
+
+`_PLOTLY_JS_BUNDLE` is read once at module import. `get_plotlyjs()`
+reads ~3.5 MB from disk per call; caching it took the e2e suite from
+roughly forty minutes to two.
+
+---
+
+## Configuration
+
+`ReportConfig` (Pydantic) holds `repo_path`, `output_path`, `title`,
+`branch`, `since`, `until`, `exclude_authors`, `min_commits`,
+`ranking_enabled`, `ranking_weights`, `output_format`
+(`"html" | "json" | "csv"`). A validator enforces `since < until`.
+
+`RankingWeights` holds `commits=0.30`, `lines=0.25`, `consistency=0.25`,
+`recency=0.20`, each in `[0, 1]`, with a validator enforcing that they
+sum to 1.0 within `1e-6`.
+
+`load_config_from_toml` reads via stdlib `tomllib` and flattens
+`[report]`, `[filters]`, and `[ranking]` into a `ReportConfigKwargs`
+`TypedDict`.
+
+**Precedence: an explicitly provided CLI flag always beats the config
+file.** `min_commits` carries a `None` sentinel for this reason —
+without it, `--min-commits 1` is indistinguishable from "not provided",
+and a config file setting `min_commits = 2` silently wins over an
+explicit flag.
+
+---
+
+## Ranking
+
+Contributors are scored on four components, min-max normalised, combined
+by weighted sum, then converted to percentiles and tiers.
+
+Consistency is passed through `_normalise_scores` unchanged; it is
+already in `[0, 1]`. When max equals min, every value resolves to 1.0.
+
+Recency bins commits by ISO calendar week, weights the anchor week 1.0,
+and decays each earlier week by `_RECENCY_DECAY = 0.85`.
+
+Percentiles use `bisect.bisect_left` for lower-bound semantics, so tied
+scores get identical percentiles — see
+[ADR-0003](adr/0003-bisect-left-for-percentile-ties.md).
+
+`assign_tier` walks `_TIER_BOUNDARIES` top-down on strict `>`:
+
+| Percentile above | Tier | Designation |
+|---|---|---|
+| 95.0 | 7 | Commander |
+| 88.0 | 6 | Major |
+| 75.0 | 5 | Captain |
+| 60.0 | 4 | Lieutenant |
+| 40.0 | 3 | Sergeant |
+| 20.0 | 2 | Corporal |
+| −1.0 | 1 | Private |
+
+The `-1.0` entry is an exhaustive fallback, so no valid percentile can
+fail to match. `assign_tier` raises `AssertionError` if none matches —
+unreachable in production, and a loud signal that `_TIER_BOUNDARIES`
+was misconfigured. It replaced a silent `return "Recruit"` default that
+would have hidden exactly that.
+
+> **On interpreting these numbers.** Ranking measures commit and line
+> volume. It does not measure contribution, and the professional
+> consensus — DORA and SPACE both state this explicitly — is against
+> using such metrics for individual assessment. The rankings exist to
+> show *shape of participation*, not to grade people. See the User
+> Guide for the caveat that ships to users.
+
+---
+
+## Testing
+
+| Tier | Location | Rule |
+|---|---|---|
+| Unit | `tests/unit/` | No I/O, no filesystem, no subprocess. Inputs constructed directly. |
+| Integration | `tests/integration/` | Real Git repositories built by fixtures via `subprocess`. |
+| E2E | `tests/e2e/` | Full CLI invocation through Typer's `CliRunner`. |
+
+The suite runs under `pytest-xdist` (`-n auto`). Fixtures that build
+repositories are module-scoped and use `tmp_path_factory`, not
+`tmp_path`, which is per-test and not worker-safe. Coverage gate is 90%.
+
+Several tests exist specifically to stop a guarantee eroding, and are
+worth knowing about before you change what they cover:
+
+- **Offline moat** — no `<link>`, `<script>`, or `<img>` in the output references a remote host.
+- **Layering** — no framework import crosses the boundaries above.
+- **Contrast** — WCAG AA ratios computed from the template's own CSS custom properties, so a palette edit is checked without anyone updating a fixture.
+- **Packaging** — the `py.typed` marker is present in both wheel and sdist.
+- **Workflow pins** — every GitHub Action is pinned to a commit SHA with a comment naming a precise version.
+
+---
+
+## Toolchain
+
+| Tool | Role |
+|---|---|
+| Poetry | Dependencies, virtualenv, build, publish |
+| ruff | Lint (E,W,F,I,C,B,UP,N,SIM,D,RUF) and format — the sole formatter |
+| mypy `strict` | Type checking |
+| pytest + xdist + cov | Testing, parallelism, coverage |
+| pre-commit (`repo: local`) | ruff and mypy, run inside the Poetry venv so versions cannot diverge from CI |
+| GitHub Actions | CI across Python 3.11–3.14; publish on `v*` tag |
+| PyPI OIDC trusted publisher | No stored credentials; PEP 740 attestations |
+
+`make ci` runs the same gates CI does. Run it before opening a pull
+request.

--- a/docs/adr/0001-exclude-merge-commits.md
+++ b/docs/adr/0001-exclude-merge-commits.md
@@ -1,0 +1,35 @@
+# 0001 — Merge commits are excluded unconditionally
+
+**Status:** Accepted
+
+## Context
+
+A merge commit records that two lines of history were joined. In a
+squash-and-merge or pull-request workflow it carries no authored change
+of its own, and its diff against the first parent can be enormous —
+every line from the merged branch, attributed to whoever pressed the
+button.
+
+Counting them inflates commit totals and line volumes for whoever
+performs merges, typically maintainers and release managers, in a way
+that has nothing to do with what they wrote.
+
+## Decision
+
+`GitReader.read_commits` passes `no_merges=True` unconditionally. There
+is no flag to include them.
+
+## Consequences
+
+Reveille's figures are lower than `git log --oneline | wc -l` on a
+repository that merges frequently. This surprises people who compare the
+two, so the User Guide states it.
+
+Merge-heavy workflows are not measurable through Reveille: a team whose
+integration work genuinely lives in merge commits will see that work
+missing. This is accepted rather than solved, because the alternative —
+counting merges — misattributes far more often than it informs.
+
+Making it configurable was considered and rejected. It would put a
+switch on the meaning of every number in the report, so two reports
+could not be compared without checking how each was generated.

--- a/docs/adr/0002-email-as-identity-key.md
+++ b/docs/adr/0002-email-as-identity-key.md
@@ -1,0 +1,51 @@
+# 0002 — Email is the contributor identity key
+
+**Status:** Accepted
+
+## Context
+
+Git has no concept of a user account. A commit carries a free-text name
+and email, both set by whoever authored it, neither verified. The same
+person routinely appears as several identities: a work address and a
+personal one, a laptop with a misconfigured `user.name`, a GitHub
+noreply address, a name spelled with and without an accent.
+
+Something has to decide when two commits belong to the same person, and
+every available answer is a heuristic.
+
+## Decision
+
+Contributors are keyed on **lowercased email**. Display name comes from
+the most recent commit under that key.
+
+Two normalisations run before the key is taken:
+
+1. **`.mailmap`**, all four forms from `gitmailmap(5)`, matched
+   most-specific-first (name-and-email, then email-only, then
+   name-only), case-insensitively. This is the mechanism Git itself
+   provides, and the repository owner is the right authority.
+2. **GitHub noreply folding.** The legacy
+   `username@users.noreply.github.com` and post-2017
+   `12345678+username@users.noreply.github.com` forms both exist and one
+   person commonly has both. The numeric prefix is stripped so they
+   collapse.
+
+## Consequences
+
+Email is more stable than name — people change employers more often
+than they change how they spell their own name, and a name collision
+between two people is more likely than an email collision.
+
+But the failure mode is real: **one person with two unmapped addresses
+appears as two contributors, and their commits are split across both
+rows.** Reveille cannot detect this, because nothing in Git says they
+are the same person. The fix is a `.mailmap`, which is why
+`reveille init --mailmap` generates an annotated template.
+
+The opposite failure also exists: a shared address, such as a CI bot or
+an old `root@localhost`, collapses several actors into one row. The
+four-field `.mailmap` form is the remedy, and the template documents it.
+
+Display name from the most recent commit means a rename is picked up
+automatically, at the cost of the report not matching what someone
+remembers from older history.

--- a/docs/adr/0003-bisect-left-for-percentile-ties.md
+++ b/docs/adr/0003-bisect-left-for-percentile-ties.md
@@ -1,0 +1,42 @@
+# 0003 — Percentiles use lower-bound ranking
+
+**Status:** Accepted
+
+## Context
+
+Contributors are converted from composite scores to percentiles, and
+percentiles decide tiers. Ties are common: in a small repository several
+people genuinely have identical scores, and after min-max normalisation
+exact equality is easy to hit.
+
+The original implementation used `list.index` on the sorted scores.
+`list.index` returns the position of the first equal element as
+encountered, which meant tied contributors could receive different
+percentiles depending on list order — and therefore different tiers, for
+identical work. The result was not reproducible between runs.
+
+## Decision
+
+Percentiles use `bisect.bisect_left` over the sorted scores, giving
+lower-bound rank semantics:
+
+```
+percentile = bisect_left(sorted_scores, score) / (n - 1) * 100
+```
+
+Tied scores receive the same rank, so they receive the same percentile
+and the same tier. A single contributor is defined as 100.0.
+
+## Consequences
+
+Ties are handled predictably and identically on every run, which is the
+whole point.
+
+Lower-bound means a tied group is placed at the *bottom* of its band —
+three contributors tied at rank 5 all get rank 5, not 6 or 7. This is
+the conservative reading and the conventional one, but it does mean the
+percentile of a tied group is lower than an average-rank method would
+give.
+
+`bisect_left` is also O(log n) rather than `list.index`'s O(n). That is
+not why the change was made, and it does not matter at these sizes.

--- a/docs/adr/0004-single-pass-numstat-read.md
+++ b/docs/adr/0004-single-pass-numstat-read.md
@@ -1,0 +1,49 @@
+# 0004 — History is read in a single `git log --numstat` pass
+
+**Status:** Accepted
+
+## Context
+
+Reveille needs per-commit line additions and deletions. The obvious
+GitPython route is to iterate commits and read `Commit.stats`.
+
+`Commit.stats` shells out to `git diff` **once per commit**. The process
+spawn dominates, so cost grows linearly with history and is roughly
+constant per commit regardless of how small the change is. Measured on
+this repository: **7.2 ms per commit** — about six minutes for a
+50,000-commit repository, which is an ordinary size.
+
+That put a hard ceiling on what Reveille could be pointed at.
+
+## Decision
+
+`read_commits` runs a single `git log --numstat` with an ASCII
+record/field-separated format (`\x1e` between records, `\x1f` between
+fields) and parses the stream.
+
+Separator characters are chosen because `\x1e` and `\x1f` cannot occur
+in a name, an email, or a SHA, so no quoting or escaping is needed and
+no author can break the parse with a crafted name.
+
+## Consequences
+
+Measured **0.77 ms per commit** — 9.4× faster; the same 50,000-commit
+repository drops from roughly six minutes to under forty seconds.
+
+Correctness was verified before the change landed, not assumed: output
+was compared byte-for-byte against `Commit.stats` across all 180 commits
+of this repository and all 5 fixture commits. That comparison surfaced a
+pre-existing error in a fixture's own docstring, which had been wrong
+for the life of the fixture.
+
+The cost is that Reveille now owns a parser. Text-format changes in
+`git log` are a compatibility surface that `Commit.stats` would have
+absorbed, and binary files (which `--numstat` reports as `-`) need
+explicit handling. Both are covered by unit tests over the parsing
+helpers.
+
+**This does not make ownership metrics cheap.** `--numstat` gives
+*churn* — lines added and removed per commit. A true bus factor needs
+*ownership*, which requires `git blame` per file, measured at ~12.5 ms
+per file. On a 10,000-file repository that is minutes, not seconds. See
+[0005](0005-commit-concentration-not-bus-factor.md).

--- a/docs/adr/0005-commit-concentration-not-bus-factor.md
+++ b/docs/adr/0005-commit-concentration-not-bus-factor.md
@@ -1,0 +1,52 @@
+# 0005 — The concentration metric is not called a bus factor
+
+**Status:** Accepted
+
+## Context
+
+The report showed a summary card labelled "bus factor", computed as the
+number of contributors accounting for a majority of commits.
+
+That is not a bus factor. A bus factor asks how many people would have
+to leave before the project loses the ability to maintain some part of
+itself — a question about **knowledge ownership**, which is a property
+of who understands which code, approximated by who has written and
+maintained it.
+
+Commit count answers a different question: who has been *active*. The
+two diverge in ordinary cases. Someone who wrote a critical subsystem
+years ago and has committed rarely since is a large bus-factor risk and
+a small commit-count presence. Someone doing high-volume mechanical
+changes is the reverse.
+
+The label was the problem, not the number. "Bus factor" is a term of art
+with an established meaning, and using it for a different quantity meant
+the report was making a claim about risk that its own data could not
+support — in a document written to be forwarded to stakeholders.
+
+## Decision
+
+The metric is named **commit concentration** in the UI, the code
+(`_compute_commit_concentration`), and the JSON payload
+(`derived.commit_concentration`). The User Guide states explicitly that
+it is *not* a bus factor.
+
+Computing a real bus factor was considered and rejected for now: it
+needs per-file ownership via `git blame`, measured at ~12.5 ms per file
+— minutes on a large repository, against the ~40 seconds the whole
+analysis currently takes. See
+[0004](0004-single-pass-numstat-read.md).
+
+## Consequences
+
+The report no longer implies a risk assessment it cannot make. What it
+shows is honest and still useful: concentration of activity is real
+information.
+
+The JSON key changed, which is **breaking** for anyone reading
+`derived.bus_factor`. It was accepted pre-1.0 rather than carrying a
+misleading name into the stable API.
+
+A real bus factor remains a legitimate future feature. It would be a new
+metric alongside this one, with its own cost documented — not a
+rename back.

--- a/docs/adr/0006-offline-single-file-report.md
+++ b/docs/adr/0006-offline-single-file-report.md
@@ -1,0 +1,48 @@
+# 0006 — The report is a single offline file
+
+**Status:** Accepted
+
+## Context
+
+Reveille's output is meant to be forwarded: attached to an email,
+embedded in Confluence, opened from a download folder. The people
+reading it are frequently not the people who generated it, and often not
+on the network where it was generated.
+
+Anything the page fetches at open time is a dependency on the *reader's*
+environment and a disclosure to a third party. A CDN request tells that
+CDN who opened an internal engineering report and when. A web font
+breaks the layout on an air-gapped machine. A sidecar asset directory
+does not survive being attached to an email.
+
+## Decision
+
+The report is one HTML file that makes **no network requests**. The
+Plotly bundle (~3.5 MB) is inlined. Fonts are system stacks. There are
+no external stylesheets, scripts, or images.
+
+A test asserts that no `<link>`, `<script>`, or `<img>` in the template
+references a remote host.
+
+## Consequences
+
+The file is large — several megabytes, most of it Plotly. This is the
+central trade, and it is accepted: a few megabytes is cheap next to a
+report that fails to open.
+
+It also means charting is expensive to change. Plotly is not a
+dependency that can be swapped casually, since the offline bundle is the
+thing being embedded.
+
+`plotly.offline.get_plotlyjs()` reads that bundle from disk on every
+call, so it is cached at module import in `_PLOTLY_JS_BUNDLE`. Without
+the cache the e2e suite took roughly forty minutes; with it, about two.
+
+The guarantee has one honest boundary. The generated HTML contains
+sixteen `https://` string literals, all of them inert map-attribution
+text inside the Plotly bundle. They are never fetched by any report
+Reveille produces, and no chart Reveille builds is a map. They are
+present because the bundle is shipped whole. The test asserts what
+matters — that nothing in *our* template loads a remote resource —
+rather than that the string `https://` is absent, which would be a
+weaker check dressed as a stronger one.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+Each record captures one decision that shaped Reveille, the situation
+that forced it, and what it cost. They exist so a decision is not
+silently reversed by someone who never saw the reasoning — and so a
+decision that *should* be reversed can be, with its original argument in
+view rather than reconstructed from memory.
+
+A record is written when a decision is hard to infer from the code.
+Routine choices do not need one.
+
+Records are immutable once accepted. A decision that changes gets a new
+record that supersedes the old one; the old record stays, marked
+superseded. The history is the point.
+
+## Format
+
+**Context** — the situation and the constraint. **Decision** — what was
+chosen, stated plainly. **Consequences** — what this costs, including
+what it rules out. **Status** — Accepted, Superseded by NNNN, or
+Deprecated.
+
+## Index
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-exclude-merge-commits.md) | Merge commits are excluded unconditionally | Accepted |
+| [0002](0002-email-as-identity-key.md) | Email is the contributor identity key | Accepted |
+| [0003](0003-bisect-left-for-percentile-ties.md) | Percentiles use lower-bound ranking | Accepted |
+| [0004](0004-single-pass-numstat-read.md) | History is read in a single `git log --numstat` pass | Accepted |
+| [0005](0005-commit-concentration-not-bus-factor.md) | The concentration metric is not called a bus factor | Accepted |
+| [0006](0006-offline-single-file-report.md) | The report is a single offline file | Accepted |

--- a/tests/unit/test_docs_links.py
+++ b/tests/unit/test_docs_links.py
@@ -1,0 +1,83 @@
+"""Assert that relative links between repository documents resolve.
+
+Documentation cross-references rot silently. A renamed file leaves a
+link that still looks correct in the source and 404s for the reader, and
+nothing in the build notices. This branch added a document that links
+into an ADR directory, and a CONTRIBUTING section that links into it, so
+the failure mode is now real rather than hypothetical.
+
+Only relative links are checked. External URLs would make the suite
+depend on the network and on other people's uptime, which is a worse
+trade than the coverage is worth.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# Markdown inline links: [text](target). Reference-style links and bare
+# autolinks are not used in these documents.
+_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+_DOCUMENTS = [
+    "README.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "CODE_OF_CONDUCT.md",
+    "CHANGELOG.md",
+    "docs/ARCHITECTURE.md",
+    "docs/USER_GUIDE.md",
+    "docs/adr/README.md",
+]
+
+
+def _relative_targets(path: Path) -> list[str]:
+    """Extract link targets that point inside the repository.
+
+    Args:
+        path: The Markdown file to scan.
+
+    Returns:
+        Link targets with any `#fragment` stripped, excluding external
+        URLs and pure in-page anchors.
+    """
+    targets = []
+    for raw in _LINK.findall(path.read_text(encoding="utf-8")):
+        target = raw.split()[0].strip()
+        if target.startswith(("http://", "https://", "mailto:", "#", "<")):
+            continue
+        targets.append(target.split("#")[0])
+    return [t for t in targets if t]
+
+
+@pytest.mark.unit
+class TestDocumentationLinks:
+    """Tests that in-repository documentation links point at real files."""
+
+    @pytest.mark.parametrize("document", _DOCUMENTS)
+    def test_document_exists(self, document: str) -> None:
+        """Guard the guard: a renamed document must fail loudly here."""
+        assert (_ROOT / document).is_file(), f"{document} is listed for checking but does not exist"
+
+    @pytest.mark.parametrize("document", _DOCUMENTS)
+    def test_relative_links_resolve(self, document: str) -> None:
+        path = _ROOT / document
+        broken = [
+            target
+            for target in _relative_targets(path)
+            if not (path.parent / target).resolve().exists()
+        ]
+        assert not broken, f"{document} links to missing paths: {broken}"
+
+    def test_every_adr_is_listed_in_the_index(self) -> None:
+        """An unlisted ADR is one nobody finds."""
+        adr_dir = _ROOT / "docs" / "adr"
+        on_disk = {p.name for p in adr_dir.glob("*.md")} - {"README.md"}
+        listed = set(_relative_targets(adr_dir / "README.md"))
+        assert on_disk, "no ADRs found -- the check below would be vacuous"
+        assert on_disk == listed, f"index and directory disagree: {on_disk ^ listed}"

--- a/tests/unit/test_layering.py
+++ b/tests/unit/test_layering.py
@@ -1,0 +1,92 @@
+"""Executable form of the dependency rule in `docs/ARCHITECTURE.md`.
+
+The layering contract is the project's main structural guarantee: the
+domain is testable without a repository on disk, and swapping a data
+source or an output format means writing one adapter rather than tracing
+framework calls through the codebase. A contract that only exists in a
+document erodes one convenient import at a time, and nothing fails.
+
+Each check runs in a fresh interpreter, because `sys.modules` in the
+test process is already polluted by everything the suite has imported.
+A subprocess is the only way to observe what a module *actually* pulls
+in.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+# Frameworks that must never appear in the inner layers. Pydantic is
+# deliberately absent: `domain/ranking.py` imports `RankingWeights` from
+# `config.py` by design, which is documented in ARCHITECTURE.md under
+# "One honest exception". What this list protects is the real rule --
+# the domain performs no I/O and no presentation.
+_IO_AND_PRESENTATION = ("git", "plotly", "jinja2", "typer", "click")
+
+_PROBE = """
+import sys
+import {module}
+print(",".join(sorted({{m.split(".")[0] for m in sys.modules}})))
+"""
+
+
+def _top_level_imports(module: str) -> set[str]:
+    """Import a module in a clean interpreter and report what it loaded.
+
+    Args:
+        module: Dotted module path to import.
+
+    Returns:
+        The set of top-level package names present in `sys.modules`
+        afterwards.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE.format(module=module)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return set(result.stdout.strip().split(","))
+
+
+@pytest.mark.unit
+class TestDependencyRule:
+    """Tests that inner layers do not import outer-layer frameworks."""
+
+    @pytest.mark.parametrize("module", ["reveille.domain.models", "reveille.domain.ranking"])
+    def test_domain_imports_no_io_or_presentation_framework(self, module: str) -> None:
+        loaded = _top_level_imports(module)
+        offenders = sorted(loaded & set(_IO_AND_PRESENTATION))
+        assert not offenders, f"{module} imports {offenders}, violating the dependency rule"
+
+    def test_services_does_not_import_the_cli_framework(self) -> None:
+        """The service emits ProgressEvent; it must not know about terminals."""
+        loaded = _top_level_imports("reveille.services.report")
+        assert "typer" not in loaded, (
+            "services/report.py imports Typer; progress display is the CLI's job"
+        )
+
+    def test_gitpython_is_confined_to_its_adapter(self) -> None:
+        assert "git" not in _top_level_imports("reveille.adapters.renderer")
+        assert "git" in _top_level_imports("reveille.adapters.git_reader"), (
+            "the probe found no GitPython in git_reader -- the check above proves nothing"
+        )
+
+    def test_plotly_and_jinja_are_confined_to_their_adapter(self) -> None:
+        loaded = _top_level_imports("reveille.adapters.git_reader")
+        offenders = sorted(loaded & {"plotly", "jinja2"})
+        assert not offenders, f"git_reader.py imports {offenders}; rendering belongs to renderer.py"
+
+    def test_package_root_is_import_cheap(self) -> None:
+        """`import reveille` must not drag in the whole framework stack.
+
+        The root exposes `__version__` and installs a logging
+        NullHandler. Anything that made it import Plotly would put a
+        ~3.5 MB bundle read behind every `reveille --version`.
+        """
+        loaded = _top_level_imports("reveille")
+        offenders = sorted(loaded & set(_IO_AND_PRESENTATION))
+        assert not offenders, f"importing reveille pulls in {offenders}"


### PR DESCRIPTION
### Summary
- Added docs/ARCHITECTURE.md: architecture contract, domain model, error model, pipeline, invariants.
- Added docs/adr/: six decision records with costs and exclusions.
- Added .editorconfig, .gitattributes, CODEOWNERS, CODE_OF_CONDUCT.md.
- Corrected outdated claims from ProjRecd.md; clarified domain rule.

### Verification
- make ci green: 341 tests (+23), all pre-commit hooks pass.
- Layering guard verified: injecting framework import fails tests.
- Docs link guard verified: all ADRs indexed, links resolve.

### Notes
- CODEOWNERS and Code of Conduct contact use varaprasadchilakanti / varaprasadchilakanti@gmail.com from pyproject.toml. Confirm if gmail address is correct for conduct reports.
- CODEOWNERS only effective if branch protection requires code-owner review (repo setting).
- Next branch: docs/v0.7.0-pre-release (#8).
