### PR TITLE
docs/v0.7.0-pre-release: correct false claims and document the ranking rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,54 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The User Guide claimed the four-field `.mailmap` form was unsupported.** It has been
+  supported since the mailmap work landed earlier in this release, so the guide was
+  telling users a capability they had did not exist. The claim appeared in two places —
+  the identity-resolution walkthrough and the `reveille init --mailmap` reference, where
+  the form was described as "marked as unsupported by Reveille in this release". Both now
+  describe all four `gitmailmap(5)` forms, the most-specific-match precedence Reveille
+  follows, case-insensitive matching, and the automatic folding of GitHub noreply
+  addresses.
+
+- **`CONTRIBUTING.md` claimed CI runs across Python 3.11 and 3.12.** The matrix has
+  covered 3.11 through 3.14 since the support-policy change earlier in this release. It
+  now refers to the support policy rather than restating a version list that will drift
+  again.
+
+- **A `RankingWeights` docstring contradicted its own code**, documenting a `1e-9`
+  tolerance where the validator uses `1e-6`.
+
 ### Added
+
+- **The ranking weights are now justified rather than merely stated.** The defaults
+  (30/25/25/20) appeared in the README, the User Guide, and two docstrings with no
+  recorded reasoning anywhere in the codebase — the one part of Reveille most likely to be
+  questioned was the one part that could not answer. They are now documented as a
+  judgement rather than a derived model, with the reasoning for their relative ordering:
+  commits weighted highest for robustness, lines lower because a lockfile or reformatting
+  pass distorts them, recency lowest because recency is a property of the analysis window
+  rather than of the person.
+
+- **Documentation of what the ranking does not measure.** The README, the User Guide, and
+  `domain/ranking.py` now state plainly that the ranking measures volume and regularity of
+  commits — not contribution, productivity, or value — and that it must not be used to
+  assess individuals, which is the explicit position of both DORA and SPACE. The military
+  tier designations are described as a visual device, not a rank, and `--no-ranking` is
+  documented as the way to drop scores while keeping every other section of the report.
+
+- **`llms.txt`** — a short index pointing a coding assistant at the right document, plus
+  the handful of facts about Reveille that are easy to get wrong: that it never writes to
+  a repository, that merge commits are excluded so its counts are lower than `git log`,
+  that commit concentration is not a bus factor, and that the ranking must not be used to
+  assess individuals. It is a proposed convention, not a standard, and nothing depends
+  on it.
+
+- **The link test now checks absolute self-referential URLs.** The README and `llms.txt`
+  link to their own repository by full URL so they render correctly on PyPI, which the
+  relative-path check could not see; 17 such links are now verified to point at files that
+  exist.
 
 - **`docs/ARCHITECTURE.md` documents how Reveille is built.** The architecture record
   previously existed only in a gitignored working file, so a contributor cloning the
@@ -69,6 +116,15 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   seam in the release path.
 
 ### Changed
+
+- **The User Guide documents the single-pass history read.** The pipeline walkthrough now
+  states the measured cost (~0.8 ms per commit, so a 50,000-commit history reads in under
+  a minute) and states explicitly that Reveille never writes to the repository — no
+  commits, no branches, no configuration changes, no mutating Git command.
+
+- **Two module docstrings predated JSON and CSV export.** `services/report.py` described
+  step 7 as rendering HTML, and `adapters/renderer.py` called itself the "HTML report
+  renderer". Both now describe the three-format dispatch.
 
 - **`CONTRIBUTING.md` no longer claims the domain layer has no framework imports.** It
   does have one: `domain/ranking.py` imports `RankingWeights` from `config.py`, which is a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,10 @@ none.
 ## Submitting Pull Requests
 
 All pull requests must target the `main` branch. The CI pipeline runs
-`ruff`, `mypy`, and `pytest` across Python 3.11 and 3.12. All three
-must pass. A pull request will not be merged if any check fails.
+`ruff`, `mypy`, and `pytest` across every supported Python version — see
+[Supported Python versions](#supported-python-versions) — plus a
+packaging check and a version-consistency check. All must pass. A pull
+request will not be merged if any check fails.
 
 The output contract is non-negotiable and must be preserved in every
 contribution: the generated file is always a single self-contained

--- a/README.md
+++ b/README.md
@@ -234,6 +234,28 @@ Reveille assigns each contributor a tier designation based on a weighted composi
 
 Weights are configurable. See [Configuration](#configuration).
 
+**These defaults are a documented judgement, not a derived model.** No study
+establishes that these four signals in this proportion measure anything in
+particular. Commit volume is weighted highest because it is the most robust of
+the four — insensitive to file type and to how a change is split across lines.
+Lines are weighted lower because a lockfile or a reformatting pass can dwarf
+months of considered work. Recency is weighted lowest deliberately: recency is a
+property of the analysis window rather than of the person, so weighting it higher
+makes the same contributor's tier swing on the choice of end date.
+
+**What this measures is the volume and regularity of commits — not
+contribution, productivity, or value.** Both DORA and SPACE, the two most widely
+cited bodies of research on software delivery measurement, state explicitly that
+their metrics must not be used to assess individuals. Activity metrics are easy
+to game and systematically misread review-heavy, mentoring, part-time, and
+on-call work as low output. A contributor who spends a quarter unblocking others
+and deleting a subsystem will rank below one who committed generated files.
+
+Read a tier as a description of the shape of participation in one window, never
+as a judgement about a person. If that framing does not fit your use, turn
+ranking off with `--no-ranking` or `ranking.enabled = false`; the plain
+contributor table remains.
+
 The composite score maps to the following tier designations, applied relative to the contributor population in the analysis window.
 
 | Tier | Designation | Composite Score Percentile |
@@ -299,6 +321,12 @@ For how Reveille is built rather than how it is used, see
 invariants the test suite protects. Individual design decisions and the
 reasoning behind them are recorded in
 [docs/adr/](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/adr/).
+
+The repository also carries an
+[llms.txt](https://github.com/varaprasadchilakanti/reveille/blob/main/llms.txt)
+index, which points a coding assistant at the right document and states the
+handful of facts about Reveille that are easy to get wrong. `llms.txt` is a
+proposed convention rather than a standard, and nothing depends on it.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -32,6 +32,14 @@ unconditionally excluded at this stage because they inflate both commit
 counts and line change volumes without reflecting individual contributor
 activity.
 
+This is a single `git log --numstat` pass over the requested range,
+which is why the read scales to large repositories: it costs roughly
+0.8 milliseconds per commit, so a 50,000-commit history is read in
+under a minute rather than the several minutes a per-commit diff would
+take. Reveille never writes to the repository — no commits, no
+branches, no configuration changes, no mutating Git command at any
+point. The only file it writes is the output file you name.
+
 Second, raw commits are aggregated into per-contributor statistics. A
 contributor's identity is keyed on their author email address, not their
 display name. This means that a contributor who has committed under two
@@ -42,9 +50,21 @@ the repository root, email aliases are resolved to their canonical
 identity before aggregation. A contributor who has committed under
 multiple email addresses is unified under the canonical identity declared
 in `.mailmap`, ensuring that ranking and contribution metrics reflect
-actual individual output rather than the number of addresses used. The
-four-field `.mailmap` form is not yet supported and is documented as a
-known limitation.
+actual individual output rather than the number of addresses used.
+
+All four `.mailmap` forms defined by `gitmailmap(5)` are supported, and
+matching follows Git's own precedence: the most specific rule wins.
+A rule naming both a name and an email is tried first, then one naming
+an email alone, then one naming a name alone. Matching is
+case-insensitive, and malformed lines are skipped silently — again
+matching Git's behaviour, so a `.mailmap` that works with `git shortlog`
+works here.
+
+GitHub noreply addresses are folded automatically, with no `.mailmap`
+entry required. The legacy `username@users.noreply.github.com` and the
+post-2017 `12345678+username@users.noreply.github.com` forms both exist,
+and the same person frequently appears under both; the numeric prefix is
+stripped so the two collapse into one contributor.
 
 Third, each contributor is scored using the weighted composite ranking
 algorithm and assigned a tier designation relative to the other
@@ -278,7 +298,7 @@ reveille init --force
 
 ### `--mailmap`
 
-Generates a fully annotated `.mailmap` template at the repository root alongside `reveille.toml`. The template documents the two-field form (name correction), three-field form (email alias to canonical identity), and four-field form (name and email alias, marked as unsupported by Reveille in this release), each with concrete examples covering employer domain changes, GitHub noreply addresses, and name corrections.
+Generates a fully annotated `.mailmap` template at the repository root alongside `reveille.toml`. The template documents all four forms defined by `gitmailmap(5)` — name correction, email alias to canonical identity, email-only remapping, and the four-field form that disentangles several people sharing one address — each with concrete examples covering employer domain changes, GitHub noreply addresses, name corrections, and shared build-machine accounts. It also documents the matching precedence, so a rule that does not fire can be diagnosed from the template itself.
 
 `--force` applies to both generated files when `--mailmap` is set. If a `.mailmap` file already exists, it is silently skipped — `.mailmap` is a Git-native file and its presence is not treated as a conflict.
 
@@ -475,6 +495,22 @@ summed to produce the composite score. The default weights are commit
 volume at 30 percent, lines contributed at 25 percent, consistency at 25
 percent, and recency at 20 percent.
 
+**Why those numbers.** They are a documented judgement, not a derived
+model — no study establishes that these four signals in this proportion
+measure anything in particular. Commit volume is highest because it is
+the most robust of the four: insensitive to file type, to generated
+code, and to how a change happens to be split across lines. Lines are
+lower because they are the easiest to distort — a vendored dependency, a
+lockfile, or a reformatting pass can dwarf months of considered work.
+Consistency rewards sustained participation over a single burst. Recency
+is lowest deliberately, because recency is a property of the analysis
+window rather than of the person; weight it higher and the same
+contributor's tier swings on the choice of end date.
+
+They are configurable precisely because they are a judgement. If the
+defaults do not describe what you are trying to see, change them — see
+[Adjusting Weights for a Maintenance Quarter](#adjusting-weights-for-a-maintenance-quarter).
+
 Each contributor's composite score is then converted to a percentile
 rank within the population. The percentile determines the tier designation
 according to the following table.
@@ -489,8 +525,36 @@ according to the following table.
 | VI | Major | 89th – 95th |
 | VII | Commander | 96th – 100th |
 
+Tied composite scores receive identical percentiles, and therefore
+identical tiers. Percentile is a lower-bound rank, so a tied group sits
+at the bottom of its band rather than being ordered arbitrarily.
+
 In a repository with a single contributor, that contributor receives the
 Commander designation by definition, as their percentile is 100.0.
+
+### What the ranking does not measure
+
+The ranking measures the volume and regularity of commits, because that
+is what Git records. It does not measure contribution, productivity, or
+value, and it should not be used to assess an individual.
+
+This is the stated position of the research rather than a disclaimer.
+Both DORA and SPACE — the two most widely cited bodies of work on
+software delivery measurement — say explicitly that their metrics must
+not be applied to individuals. Activity metrics are easy to game and
+systematically misread review-heavy, mentoring, part-time, and on-call
+work as low output. A contributor who spends a quarter unblocking
+colleagues and deleting a subsystem will rank below one who committed
+generated files.
+
+Read a tier as a description of the shape of participation in one
+window. It is not a statement about a person, and the military
+designations are a visual device, not a rank.
+
+If that framing does not fit your use, turn ranking off entirely with
+`--no-ranking` or `ranking.enabled = false`. The contributor table,
+heatmap, timelines, and breakdown charts all remain; only the scores,
+percentiles, and tiers are dropped.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,33 @@
+# Reveille
+
+> A Python CLI that reads a local Git repository and writes a single self-contained HTML report on its contribution history. It is read-only, works entirely offline, and sends nothing anywhere — the report embeds its own chart library so it opens on a machine with no network. Install with `pip install reveille`; run `reveille generate`.
+
+Reveille is forge-agnostic by construction: it reads `.git` on disk, so GitHub, GitLab, Bitbucket, and bare repositories all work with no configuration. It was built because Bitbucket has no contribution heatmap.
+
+Key facts an answer about Reveille should get right:
+
+- It never writes to a repository. No commits, no branches, no config changes, no mutating Git command. The only file written is the output path you name.
+- Merge commits are excluded unconditionally, so its commit counts are lower than `git log | wc -l` on a merge-heavy repository. This is deliberate and not configurable.
+- Contributors are keyed on lowercased email. All four `.mailmap` forms are supported, and GitHub noreply addresses are folded automatically.
+- The "commit concentration" metric is **not** a bus factor. It measures activity concentration, not code ownership.
+- Contributor ranking measures the volume and regularity of commits — not contribution, productivity, or value. It must not be used to assess individuals; DORA and SPACE both say so explicitly. It can be turned off with `--no-ranking`.
+- Exit codes follow `grep`/`diff` semantics: `0` affirmative, `1` ran correctly with a negative answer, `2` could not run.
+- Requires Python 3.11+. Licensed MIT.
+
+## Docs
+
+- [README](https://github.com/varaprasadchilakanti/reveille/blob/main/README.md): overview, installation, CLI reference, ranking system, configuration
+- [User Guide](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/USER_GUIDE.md): every flag and its interactions, exit codes, the full TOML reference, how to read each report section, and worked patterns
+- [Architecture](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/ARCHITECTURE.md): layering contract, domain model, error model, analysis pipeline, and the invariants the tests protect
+- [Architecture Decision Records](https://github.com/varaprasadchilakanti/reveille/blob/main/docs/adr/README.md): why merge commits are excluded, why email is the identity key, why concentration is not called a bus factor, and what each decision costs
+
+## Development
+
+- [Contributing](https://github.com/varaprasadchilakanti/reveille/blob/main/CONTRIBUTING.md): environment setup, supported Python versions, the layering rule, PR contract, commit conventions
+- [Security policy](https://github.com/varaprasadchilakanti/reveille/blob/main/SECURITY.md): reporting, release integrity, PEP 740 attestation verification, SBOM
+- [Changelog](https://github.com/varaprasadchilakanti/reveille/blob/main/CHANGELOG.md): full release history, Keep a Changelog format
+
+## Optional
+
+- [Code of Conduct](https://github.com/varaprasadchilakanti/reveille/blob/main/CODE_OF_CONDUCT.md): Contributor Covenant 2.1
+- [Licence](https://github.com/varaprasadchilakanti/reveille/blob/main/LICENSE): MIT

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -1,8 +1,15 @@
-r"""HTML report renderer adapter.
+r"""Report renderer adapter.
 
-Combines Jinja2 templating with Plotly chart generation to produce
-a single self-contained HTML file. All JavaScript, CSS, and chart
-data are embedded inline. The output requires no internet connection.
+Renders `ReportData` to one of three formats. `render` produces the
+HTML report; `render_json` and `render_csv` produce machine-readable
+output for downstream tooling. This is the only layer in Reveille that
+imports Jinja2 or Plotly.
+
+The HTML path combines Jinja2 templating with Plotly chart generation
+to produce a single self-contained file. All JavaScript, CSS, and chart
+data are embedded inline. The output makes no network requests, which
+is what makes it safe to forward to someone who will open it on an
+unknown machine.
 
 Chart rendering strategy: each chart is serialised as a Plotly JSON
 specification and embedded in the document as an application/json

--- a/src/reveille/config.py
+++ b/src/reveille/config.py
@@ -23,8 +23,37 @@ OutputFormat = Literal["html", "json", "csv"]
 class RankingWeights(BaseModel):
     """Configurable weights for the contributor ranking composite score.
 
-    All four weights must sum to 1.0. Validation enforces this invariant
-    at construction time.
+    All four weights must sum to 1.0, so the composite score stays
+    bounded to [0.0, 1.0] and remains comparable across runs. Validation
+    enforces this at construction time.
+
+    **The defaults are a judgement call, not an empirically derived
+    model.** No study establishes that these four signals in this
+    proportion measure anything in particular. They are documented here
+    so the judgement can be argued with, and they are configurable so it
+    can be overridden.
+
+    The reasoning behind their relative ordering:
+
+    - `commits` (0.30) is weighted highest because commit count is the
+      most robust of the four. It is insensitive to file type, to
+      generated code, and to how a change happens to be split across
+      lines.
+    - `lines` (0.25) captures volume, but is the easiest to distort:
+      a vendored dependency, a lockfile, or a reformatting pass can
+      dwarf months of considered work.
+    - `consistency` (0.25) is active days over window days. It rewards
+      sustained participation over a single burst, which is the closest
+      any of these gets to a durability signal.
+    - `recency` (0.20) is weighted lowest deliberately. Recency is a
+      property of the analysis window rather than of the person; weight
+      it higher and the same contributor's tier swings on the choice of
+      end date.
+
+    None of this makes the composite a measure of contribution. It
+    measures volume and regularity of commits, which is what Git
+    records. See `reveille.domain.ranking` for the caveat that belongs
+    with any use of it.
     """
 
     commits: float = Field(default=0.30, ge=0.0, le=1.0)
@@ -40,7 +69,7 @@ class RankingWeights(BaseModel):
             The validated RankingWeights instance.
 
         Raises:
-            ValueError: If the sum deviates from 1.0 by more than 1e-9.
+            ValueError: If the sum deviates from 1.0 by more than 1e-6.
         """
         total = self.commits + self.lines + self.consistency + self.recency
         if abs(total - 1.0) > 1e-6:

--- a/src/reveille/domain/ranking.py
+++ b/src/reveille/domain/ranking.py
@@ -5,6 +5,28 @@ on configurable weighted metrics. Rankings are relative to the
 contributor population within a single analysis window -- no absolute
 thresholds are applied.
 
+What this measures, and what it does not
+----------------------------------------
+It measures the volume and regularity of commits, because that is what
+Git records. It does not measure contribution, productivity, or value.
+The distance between those two sentences is the whole caveat.
+
+This is not a matter of taste. Both DORA and SPACE -- the two most
+widely cited bodies of research on software delivery measurement --
+state explicitly that their metrics must not be used to assess
+individuals, because activity metrics are trivially gameable and
+systematically misread part-time, review-heavy, mentoring, and
+on-call work as low output.
+
+A contributor who spends a quarter reviewing others' code, unblocking
+people, and deleting a subsystem will rank below one who committed
+generated files. That is not a defect in the implementation; it is what
+commit-derived metrics are. Treat a tier as a description of the *shape
+of participation* in one window, never as a judgement about a person.
+
+Ranking is opt-out via `ranking_enabled=False`, which keeps the plain
+contributor table and drops scores, percentiles, and tiers.
+
 Normalisation is min-max within the population for each metric except
 consistency, which is already bounded to [0.0, 1.0] as a ratio. When
 the population contains only one contributor, all normalised scores
@@ -32,6 +54,10 @@ Default metric weights (must sum to 1.0):
     lines            0.25
     consistency      0.25
     recency          0.20
+
+These are a documented judgement, not a derived model. See
+`reveille.config.RankingWeights` for the reasoning behind their relative
+ordering and for how to override them.
 """
 
 from __future__ import annotations

--- a/src/reveille/services/report.py
+++ b/src/reveille/services/report.py
@@ -7,11 +7,17 @@ Orchestrates the full report generation pipeline:
     4. Aggregate contributor statistics.
     5. Rank contributors using the ranking engine.
     6. Assemble the ReportData object.
-    7. Render the HTML output via the Renderer adapter.
+    7. Render to the configured format via the Renderer adapter --
+       HTML, JSON, or CSV, dispatched on `config.output_format`.
     8. Return the absolute path of the written file.
 
 This layer has no direct knowledge of GitPython, Jinja2, Plotly,
 or Typer. All external concerns are delegated to adapters.
+
+Progress is reported by emitting `ProgressEvent` objects to an optional
+callback, not by writing to a terminal. Whether those events become an
+animated spinner, log lines, or nothing at all is the CLI's decision;
+the service holds no opinion about output devices.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_docs_links.py
+++ b/tests/unit/test_docs_links.py
@@ -1,14 +1,19 @@
-"""Assert that relative links between repository documents resolve.
+"""Assert that links between repository documents resolve.
 
 Documentation cross-references rot silently. A renamed file leaves a
 link that still looks correct in the source and 404s for the reader, and
-nothing in the build notices. This branch added a document that links
-into an ADR directory, and a CONTRIBUTING section that links into it, so
-the failure mode is now real rather than hypothetical.
+nothing in the build notices.
 
-Only relative links are checked. External URLs would make the suite
-depend on the network and on other people's uptime, which is a worse
-trade than the coverage is worth.
+Two link styles are checked, because the documents use both. Relative
+paths appear between documents in `docs/`. Absolute
+`github.com/.../blob/main/...` URLs appear in the README and `llms.txt`,
+which must render correctly on PyPI and when quoted out of context —
+those resolve to a repository path just the same, and go stale just the
+same.
+
+Links to genuinely external sites are *not* checked. Doing so would make
+the suite depend on the network and on other people's uptime, which
+buys less than it costs.
 """
 
 from __future__ import annotations
@@ -23,6 +28,12 @@ _ROOT = Path(__file__).resolve().parents[2]
 # Markdown inline links: [text](target). Reference-style links and bare
 # autolinks are not used in these documents.
 _LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+# Self-referential links written as absolute URLs. The README and
+# llms.txt use these so they render correctly on PyPI and when quoted
+# out of context, which means the plain relative-path check below cannot
+# see them -- and a renamed file leaves them broken and unnoticed.
+_SELF_URL = re.compile(r"https://github\.com/varaprasadchilakanti/reveille/blob/main/([^)\s#]+)")
 
 _DOCUMENTS = [
     "README.md",
@@ -73,6 +84,26 @@ class TestDocumentationLinks:
             if not (path.parent / target).resolve().exists()
         ]
         assert not broken, f"{document} links to missing paths: {broken}"
+
+    @pytest.mark.parametrize("document", [*_DOCUMENTS, "llms.txt"])
+    def test_self_referential_urls_point_at_real_paths(self, document: str) -> None:
+        """A `blob/main/...` URL naming a file this repository no longer has."""
+        path = _ROOT / document
+        targets = _SELF_URL.findall(path.read_text(encoding="utf-8"))
+        broken = [t for t in targets if not (_ROOT / t).exists()]
+        assert not broken, f"{document} links to repository paths that do not exist: {broken}"
+
+    def test_llms_txt_is_well_formed(self) -> None:
+        """`llms.txt` requires an H1; the blockquote summary is by convention.
+
+        Both are what a consuming model reads first, so an empty or
+        heading-less file is worse than no file at all.
+        """
+        lines = (_ROOT / "llms.txt").read_text(encoding="utf-8").splitlines()
+        assert lines[0].startswith("# "), "llms.txt must open with an H1 naming the project"
+        assert any(line.startswith("> ") for line in lines[:5]), (
+            "llms.txt should carry a blockquote summary near the top"
+        )
 
     def test_every_adr_is_listed_in_the_index(self) -> None:
         """An unlisted ADR is one nobody finds."""


### PR DESCRIPTION
### Summary
- Corrected false claims: .mailmap support, Python version list, RankingWeights tolerance.
- Documented ranking weights as judgement, not derived model; rationale for relative ordering added.
- README, User Guide, and domain/ranking.py updated with explicit caveats: ranking measures commit volume/regularity, not contribution or value; must not assess individuals.
- Added llms.txt per llmstxt.org structure; clarified facts and caveats.
- Corrected outdated module docstrings.

### Verification
- make ci green: 351 tests (+10), all 9 pre-commit hooks pass.
- Link test extended to absolute blob/main/... URLs; 17 verified.
- Mutation-checked: restoring false claims fails tests.

### Notes
- This branch lowers urgency of D-9 but does not close it; ranking still defaults on.
- Next branch: chore/release-v0.7.0 (version bump, changelog promotion, SECURITY.md to 0.7.x).
