### PR TITLE
fix/install-and-cli-docs: correct typer metadata and CLI documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
 
 ### Fixed
 
+- **`pip install reveille` printed a warning on every install.** The Typer dependency was
+  declared as `typer[all]`, and Typer declares no extras at any version in the supported
+  range, so pip emitted `WARNING: typer 0.27.1 does not provide the extra 'all'` — the
+  first thing a new user saw. The extra was never load-bearing: `rich` and `shellingham`,
+  what it used to pull, are ordinary dependencies of `typer` itself, and `typer-slim` is
+  the variant that omits them. Verified at both ends of the range (0.18.0 and 0.27.1):
+  neither declares an extra, and both install `rich` and `shellingham` regardless. The
+  resolved dependency set is byte-identical — only the lock file's content hash changed.
+
+- **The README documented a `reveille version` command that does not exist.** The version
+  string is exposed as a global `--version` / `-v` flag; there is no `version` subcommand,
+  so anyone copying the invocation out of the CLI reference got
+  `No such command 'version'`. Found by running it rather than by reading it — every
+  documentation guard in this release compares text to text, which is why it survived them
+  all.
+
 - **The User Guide claimed the four-field `.mailmap` form was unsupported.** It has been
   supported since the mailmap work landed earlier in this release, so the guide was
   telling users a capability they had did not exist. The claim appeared in two places —
@@ -114,6 +130,14 @@ Versioning follows [Semantic Versioning 2.0](https://semver.org/).
   trailing comment names a precise version. An action referenced by a mutable tag executes
   whatever that tag points at on the day the workflow runs, which is an arbitrary-code
   seam in the release path.
+
+- **Two tests hold the CLI reference to the CLI.** One asserts `reveille version` fails.
+  The other compares the commands named in the README's CLI Reference against the commands
+  Typer actually registered, in both directions — a documented command that does not
+  exist, and a real command the README omits. The commands are read from the Typer group
+  rather than parsed out of `--help` text: a first attempt did parse the help output and
+  passed while the README documented a nonexistent command, because the name matched
+  inside an option's description sentence.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,14 @@ Scaffolds a fully annotated `reveille.toml` configuration file in the current di
 | `--force` | | Flag | Off | Overwrite an existing file at the target path without prompting. |
 | `--mailmap` | | Flag | Off | Generate an annotated `.mailmap` template at the repository root alongside `reveille.toml`. Documents two-field, three-field, and four-field format variants with real-world examples. An existing `.mailmap` is silently skipped. |
 
-### `reveille version`
+### `reveille --version` / `-v`
 
-Prints the installed version string and exits.
+Prints the installed version string and exits. This is a global flag rather than
+a subcommand — `reveille version` is not a valid invocation.
+
+```bash
+reveille --version
+```
 
 ### `reveille validate`
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1294,4 +1294,4 @@ python-discovery = ">=1.4.2"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "dab478e9614600cac3cd01225e7e366f6c34159887cd29a6ec489083b9498ba5"
+content-hash = "3530e5b93799ebf4311bae751ed6a9e3d8d5d0162ac6ffe6015d8d85ce41b643"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,14 @@ python = "^3.11"
 # CLI Layer
 # Typer 0.18.0 restored full Click 8.3.x compatibility. The <8.3.0 upper
 # bound introduced in v0.3.0 is no longer required.
-typer = { version = ">=0.18,<0.28", extras = ["all"] }
+#
+# Deliberately no `extras = ["all"]`. Typer declares no extras at any
+# version in this range, so pip emitted "typer X does not provide the
+# extra 'all'" on every install. It was never load-bearing: `rich` and
+# `shellingham` -- what the extra used to pull -- are ordinary
+# dependencies of `typer` itself. `typer-slim` is the variant that omits
+# them, and Reveille does not use it.
+typer = ">=0.18,<0.28"
 click = ">=8.0.0"
 
 # Git Data Layer

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import typer.main
 from typer.testing import CliRunner
 
 from reveille import __version__
@@ -148,6 +149,59 @@ class TestVersionCommand:
         result = runner.invoke(app, ["-v"])
         assert result.exit_code == 0
         assert __version__ in result.stdout
+
+    def test_version_is_not_a_subcommand(self) -> None:
+        """`reveille version` must fail, because the README once said it worked.
+
+        The version string is exposed as a global flag. The README
+        documented a `reveille version` subcommand through v0.6.x; it
+        never existed, and anyone who copied it from the CLI reference
+        got 'No such command'.
+        """
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code != 0
+
+
+@pytest.mark.e2e
+class TestDocumentedCommandsExist:
+    """Every command in the README's CLI Reference must be real.
+
+    A CLI reference is a promise. Documenting a command that does not
+    exist is worse than omitting it, because a reader who copies it gets
+    an error and no way to tell whether the tool or the documentation is
+    wrong.
+    """
+
+    def _documented_commands(self) -> set[str]:
+        readme = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
+        # CLI Reference subsections read `### \`reveille <name>\``.
+        # Flags are documented as `--flag`, so requiring a leading
+        # lowercase letter excludes them from the command set.
+        return set(re.findall(r"^### `reveille ([a-z][a-z-]*)`", readme, re.MULTILINE))
+
+    def _registered_commands(self) -> set[str]:
+        """Read the commands Typer actually registered.
+
+        Deliberately not parsed out of `--help` text. An earlier version
+        of this test did exactly that and passed while the README
+        documented a command that did not exist -- the name matched
+        inside an option's description sentence rather than the command
+        list. Interrogating the group is exact.
+        """
+        return set(typer.main.get_command(app).commands)
+
+    def test_registered_commands_are_discoverable(self) -> None:
+        """Guard the guard: both checks are vacuous if either set is empty."""
+        assert self._registered_commands()
+        assert self._documented_commands()
+
+    def test_readme_documents_commands_that_exist(self) -> None:
+        missing = sorted(self._documented_commands() - self._registered_commands())
+        assert not missing, f"README documents commands the CLI does not provide: {missing}"
+
+    def test_every_real_command_is_documented(self) -> None:
+        undocumented = sorted(self._registered_commands() - self._documented_commands())
+        assert not undocumented, f"CLI provides commands the README omits: {undocumented}"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
### Summary
- Dropped unused typer extras; verified metadata-only change.
- Corrected README version claim and CLI documentation.
- Added guard tests for CLI version output.

### Verification
- make ci green: 355 tests passing, all 9 pre-commit hooks clean.
- Clean-venv wheel install prints no warnings.
- poetry lock hash changed only; no packages added or removed.
- CLI still renders with rich formatting.

### Notes
- Version remains 0.6.0; bump belongs to release branch.
- Next step: chore/release-v0.7.0 off new main, re-run promotion script, SECURITY.md → 0.7.x.
