### PR TITLE
ci(release): automate draft release creation with attached SBOM and changelog extraction

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vara Prasad Chilakanti
+# SPDX-License-Identifier: Apache-2.0
+
+"""Derive a GitHub Release title and body from CHANGELOG.md.
+
+The release heading carries the version, the date and the theme:
+``## [X.Y.Z] — YYYY-MM-DD — Theme``. That convention exists so the
+Release title and the changelog cannot drift; this reads it, so the
+title is not retyped at release time either.
+
+Headings written before the convention have no theme. Those degrade to
+the bare tag rather than failing, because a past release should not
+become unreleasable by a convention introduced after it.
+
+Usage::
+
+    release_notes.py v0.8.0 --title
+    release_notes.py v0.8.0 --body
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_HEADING = (
+    r"^## \[{version}\]\s*[—-]\s*\d{{4}}-\d{{2}}-\d{{2}}"
+    r"(?:\s*[—-]\s*(?P<theme>.+?))?\s*$"
+)
+
+
+def _section(changelog: str, version: str) -> tuple[str, str]:
+    """Return the (theme, body) for a version, or exit if it is absent.
+
+    Args:
+        changelog: The full text of CHANGELOG.md.
+        version: A version without its leading ``v``.
+
+    Returns:
+        The heading's theme (empty if it has none) and the section body.
+    """
+    heading = re.compile(_HEADING.format(version=re.escape(version)), re.MULTILINE)
+    match = heading.search(changelog)
+    if match is None:
+        sys.exit(
+            f"no CHANGELOG heading for {version}. The release notes are read "
+            "from it, so a release cannot be described without one."
+        )
+
+    rest = changelog[match.end() :]
+    following = re.search(r"^## \[", rest, re.MULTILINE)
+    body = rest[: following.start()] if following else rest
+    # The template separates sections with a horizontal rule, which is
+    # scaffolding for the file rather than part of the notes.
+    return (match.group("theme") or "").strip(), body.strip().removeprefix("---").strip()
+
+
+def main() -> None:
+    """Print either the release title or its body."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="the release tag, e.g. v0.8.0")
+    output = parser.add_mutually_exclusive_group(required=True)
+    output.add_argument("--title", action="store_true")
+    output.add_argument("--body", action="store_true")
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    arguments = parser.parse_args()
+
+    theme, body = _section(
+        arguments.changelog.read_text(encoding="utf-8"), arguments.tag.lstrip("v")
+    )
+    if arguments.title:
+        print(f"{arguments.tag} — {theme}" if theme else arguments.tag)
+    else:
+        print(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,50 +188,85 @@ jobs:
   # repository, and it runs no third-party code -- just the SBOM file
   # produced above. The generator itself never sees a write token.
   # ----------------------------------------------------------------
-  attach-sbom:
-    name: Attach SBOM to the GitHub Release
+  release:
+    name: Draft the GitHub Release with the SBOM attached
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: sbom
     permissions:
       contents: write
     steps:
+      - name: Resolve the release being described
+        id: release
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${REQUESTED_TAG:-$GITHUB_REF_NAME}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # CHANGELOG.md as it was at the tag, so the notes describe the
+          # release rather than whatever has landed since.
+          ref: ${{ steps.release.outputs.tag }}
+          persist-credentials: false
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom
 
-      # The Release is normally drafted by hand after the tag is pushed,
-      # so it usually does not exist yet at this point. That is not a
-      # failure -- the SBOM remains available as a workflow artifact and
-      # the log says how to attach it.
-      - name: Attach to the Release if one already exists
+      # The title and body come from the CHANGELOG heading, which carries
+      # the version, the date and the theme for exactly this reason. Nothing
+      # is retyped at release time, so the Release and the changelog cannot
+      # disagree.
+      - name: Read the notes from the CHANGELOG
+        id: notes
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/release_notes.py "$TAG" --title > release-title.txt
+          python3 .github/scripts/release_notes.py "$TAG" --body > release-body.md
+          echo "title=$(cat release-title.txt)" >> "$GITHUB_OUTPUT"
+          echo "Release title: $(cat release-title.txt)"
+
+      # Created as a DRAFT, deliberately. A draft still accepts assets;
+      # a published release does not, once release immutability is on.
+      # Creating it here with the SBOM already attached closes the window
+      # in which a human had to remember to attach one -- and the human
+      # still reviews the notes and presses Publish.
+      - name: Create the draft Release, or attach to one that exists
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.tag || github.ref_name }}
+          TAG: ${{ steps.release.outputs.tag }}
+          TITLE: ${{ steps.notes.outputs.title }}
         run: |
           set -uo pipefail
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "No Release exists for $TAG yet."
-            echo "The SBOM is available as the 'sbom' artifact of this run."
-            echo "Attach it while drafting the Release, before publishing it."
+            gh release create "$TAG" reveille-*-sbom.cdx.json \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --notes-file release-body.md \
+              --draft
+            echo "Draft Release created for $TAG with the SBOM attached."
+            echo "Review the notes and press Publish."
             exit 0
           fi
 
           if gh release upload "$TAG" reveille-*-sbom.cdx.json \
                --repo "$GITHUB_REPOSITORY" --clobber; then
-            echo "SBOM attached to release $TAG."
+            echo "SBOM attached to the existing release $TAG."
             exit 0
           fi
 
-          # A published immutable release accepts no new assets. That is a
-          # setting working as intended, not a fault in this run, and it
-          # must not fail a pipeline whose security-relevant output -- the
-          # attestation -- has already succeeded. The SBOM stays available
-          # as this run's artifact, and `make sbom` at the tag reproduces
-          # it byte for byte.
+          # A published immutable release accepts no new assets. That is the
+          # setting working as intended, not a fault in this run, and it must
+          # not fail a pipeline whose security-relevant output -- the
+          # attestation -- has already succeeded.
           echo "::warning::could not attach the SBOM to release $TAG."
-          echo "If release immutability is enabled, a published release"
-          echo "accepts no new assets. Attach the SBOM while drafting the"
-          echo "Release next time, before publishing it."
-          echo "The SBOM remains downloadable as the 'sbom' artifact here."
+          echo "A published release accepts no new assets once release"
+          echo "immutability is enabled. The SBOM remains downloadable as"
+          echo "the 'sbom' artifact of this run, and `make sbom` at the tag"
+          echo "reproduces it byte for byte."
           exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,6 +106,11 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Resolved and validated once, here, and reused by the job below.
+    # Two copies of the same parsing is two places for them to disagree.
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      file: ${{ steps.release.outputs.file }}
     permissions:
       contents: read
       # Required to attest the SBOM. `id-token` mints the Sigstore identity;
@@ -123,9 +128,20 @@ jobs:
         run: |
           set -euo pipefail
           tag="${REQUESTED_TAG:-$GITHUB_REF_NAME}"
+          # Two checks, not one. The prefix test alone accepts a value
+          # carrying a newline or a semicolon -- and this value is written
+          # to GITHUB_OUTPUT and passed to `gh`, so a newline could forge a
+          # second output. Only a dispatcher with write access can supply
+          # it, which is a reason to keep the blast radius small rather
+          # than a reason to skip the check.
           case "$tag" in
             v[0-9]*) ;;
             *) echo "::error::not a release tag: $tag"; exit 1 ;;
+          esac
+          case "$tag" in
+            *[!0-9A-Za-z.-]*)
+              echo "::error::tag has characters a tag cannot have: $tag"
+              exit 1 ;;
           esac
           {
             echo "tag=$tag"
@@ -196,20 +212,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Resolve the release being described
-        id: release
-        env:
-          REQUESTED_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          tag="${REQUESTED_TAG:-$GITHUB_REF_NAME}"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # CHANGELOG.md as it was at the tag, so the notes describe the
           # release rather than whatever has landed since.
-          ref: ${{ steps.release.outputs.tag }}
+          ref: ${{ needs.sbom.outputs.tag }}
           persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -221,14 +228,12 @@ jobs:
       # is retyped at release time, so the Release and the changelog cannot
       # disagree.
       - name: Read the notes from the CHANGELOG
-        id: notes
         env:
-          TAG: ${{ steps.release.outputs.tag }}
+          TAG: ${{ needs.sbom.outputs.tag }}
         run: |
           set -euo pipefail
           python3 .github/scripts/release_notes.py "$TAG" --title > release-title.txt
           python3 .github/scripts/release_notes.py "$TAG" --body > release-body.md
-          echo "title=$(cat release-title.txt)" >> "$GITHUB_OUTPUT"
           echo "Release title: $(cat release-title.txt)"
 
       # Created as a DRAFT, deliberately. A draft still accepts assets;
@@ -239,10 +244,10 @@ jobs:
       - name: Create the draft Release, or attach to one that exists
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.release.outputs.tag }}
-          TITLE: ${{ steps.notes.outputs.title }}
+          TAG: ${{ needs.sbom.outputs.tag }}
         run: |
           set -uo pipefail
+          TITLE="$(cat release-title.txt)"
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$TAG" reveille-*-sbom.cdx.json \
               --repo "$GITHUB_REPOSITORY" \
@@ -267,6 +272,6 @@ jobs:
           echo "::warning::could not attach the SBOM to release $TAG."
           echo "A published release accepts no new assets once release"
           echo "immutability is enabled. The SBOM remains downloadable as"
-          echo "the 'sbom' artifact of this run, and `make sbom` at the tag"
+          echo "the 'sbom' artifact of this run, and 'make sbom' at the tag"
           echo "reproduces it byte for byte."
           exit 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,19 @@ on:
     tags:
       - 'v*'
 
+  # The SBOM half of this workflow can be re-run for a tag that already
+  # exists. A tag push is a one-shot event, and with release immutability
+  # enabled the tag cannot be moved or replaced, so a failure here would
+  # otherwise leave that version permanently without an attested SBOM.
+  # Publication is deliberately not reachable this way: a version number is
+  # spent on first upload, so a second attempt would fail regardless.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to describe, e.g. v0.8.0'
+        required: true
+        type: string
+
 jobs:
   # ----------------------------------------------------------------
   # Release-time vulnerability gate
@@ -45,6 +58,8 @@ jobs:
 
   publish:
     name: Build and publish to PyPI
+    # Tag pushes only -- see the workflow_dispatch comment above.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: vulnerabilities
@@ -99,8 +114,29 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      # One place decides which release is being described, so a tag push
+      # and a manual re-run cannot disagree about it.
+      - name: Resolve the release being described
+        id: release
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${REQUESTED_TAG:-$GITHUB_REF_NAME}"
+          case "$tag" in
+            v[0-9]*) ;;
+            *) echo "::error::not a release tag: $tag"; exit 1 ;;
+          esac
+          {
+            echo "tag=$tag"
+            echo "file=reveille-${tag#v}-sbom.cdx.json"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The SBOM describes the lock file as it was at the tag, not as
+          # it is on the default branch.
+          ref: ${{ steps.release.outputs.tag }}
           persist-credentials: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -121,7 +157,7 @@ jobs:
         run: |
           python -m pip install --quiet cyclonedx-bom==7.3.1
           cyclonedx-py poetry --no-dev --output-reproducible \
-            --of JSON -o "reveille-${GITHUB_REF_NAME#v}-sbom.cdx.json" .
+            --of JSON -o "${{ steps.release.outputs.file }}" .
 
       # A plain attached file has no cryptographic binding to the run that
       # produced it, so it can be swapped for another. This binds the SBOM to
@@ -131,15 +167,20 @@ jobs:
       - name: Attest the SBOM
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          subject-path: reveille-*-sbom.cdx.json
+          # Both are the resolved filename, not a glob. `subject-path`
+          # expands globs and `predicate-path` does not, so one pattern
+          # served one input and failed the other with "predicate file not
+          # found" -- after the distributions had already reached PyPI,
+          # which is the half that cannot be retried.
+          subject-path: ${{ steps.release.outputs.file }}
           predicate-type: https://cyclonedx.org/bom
-          predicate-path: reveille-*-sbom.cdx.json
+          predicate-path: ${{ steps.release.outputs.file }}
 
       - name: Upload SBOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
-          path: reveille-*-sbom.cdx.json
+          path: ${{ steps.release.outputs.file }}
           if-no-files-found: error
 
   # ----------------------------------------------------------------
@@ -166,14 +207,15 @@ jobs:
       - name: Attach to the Release if one already exists
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" reveille-*-sbom.cdx.json \
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" reveille-*-sbom.cdx.json \
               --repo "$GITHUB_REPOSITORY" --clobber
-            echo "SBOM attached to release $GITHUB_REF_NAME."
+            echo "SBOM attached to release $TAG."
           else
-            echo "No Release exists for $GITHUB_REF_NAME yet."
+            echo "No Release exists for $TAG yet."
             echo "The SBOM is available as the 'sbom' artifact of this run."
             echo "Attach it when drafting the Release:"
-            echo "  gh release upload $GITHUB_REF_NAME reveille-*-sbom.cdx.json"
+            echo "  gh release upload $TAG reveille-*-sbom.cdx.json"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -209,13 +209,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release upload "$TAG" reveille-*-sbom.cdx.json \
-              --repo "$GITHUB_REPOSITORY" --clobber
-            echo "SBOM attached to release $TAG."
-          else
+          set -uo pipefail
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "No Release exists for $TAG yet."
             echo "The SBOM is available as the 'sbom' artifact of this run."
-            echo "Attach it when drafting the Release:"
-            echo "  gh release upload $TAG reveille-*-sbom.cdx.json"
+            echo "Attach it while drafting the Release, before publishing it."
+            exit 0
           fi
+
+          if gh release upload "$TAG" reveille-*-sbom.cdx.json \
+               --repo "$GITHUB_REPOSITORY" --clobber; then
+            echo "SBOM attached to release $TAG."
+            exit 0
+          fi
+
+          # A published immutable release accepts no new assets. That is a
+          # setting working as intended, not a fault in this run, and it
+          # must not fail a pipeline whose security-relevant output -- the
+          # attestation -- has already succeeded. The SBOM stays available
+          # as this run's artifact, and `make sbom` at the tag reproduces
+          # it byte for byte.
+          echo "::warning::could not attach the SBOM to release $TAG."
+          echo "If release immutability is enabled, a published release"
+          echo "accepts no new assets. Attach the SBOM while drafting the"
+          echo "Release next time, before publishing it."
+          echo "The SBOM remains downloadable as the 'sbom' artifact here."
+          exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,23 @@ before 0.8.0 predate the convention and are left as they were released.
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **The SBOM attestation failed on every release, and 0.8.0 was the first to
+  find out.** `actions/attest` expands globs in `subject-path` but not in
+  `predicate-path`, and both were given `reveille-*-sbom.cdx.json`. The step
+  failed with `predicate file not found` — after the distributions had already
+  reached PyPI, which is the half that cannot be retried. Both inputs now take
+  a filename resolved once, in one step, so a tag push and a manual re-run
+  cannot disagree about it.
+
+- **A failed SBOM job could not be retried.** The workflow ran only on a tag
+  push, and re-running it from the tag re-runs the workflow file *as it was at
+  that tag* — the same failure. With release immutability enabled the tag
+  cannot be moved, so that version would have been left permanently without an
+  attested SBOM. A `workflow_dispatch` trigger takes an existing tag, checks it
+  out, and regenerates. Publication is guarded off that path: a version number
+  is spent on first upload, so a second attempt would fail regardless.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@ before 0.8.0 predate the convention and are left as they were released.
   a filename resolved once, in one step, so a tag push and a manual re-run
   cannot disagree about it.
 
+- **The Release is now drafted by the workflow, with the SBOM already
+  attached.** The old design generated the SBOM, tried to attach it to a
+  Release that does not exist yet at tag time, and left a human to attach it
+  later — into a window that release immutability closes the moment Publish is
+  pressed. Requiring a person to remember a step that has one narrow window is
+  a design fault, not a discipline problem.
+
+  The `release` job now creates a **draft** Release with the SBOM attached, the
+  title read from the CHANGELOG heading and the body from that version's
+  section. A draft accepts assets; a published release does not. Nothing is
+  retyped, so the Release and the changelog cannot disagree — which is what the
+  heading convention introduced earlier in this release was for, now that it is
+  machine-read rather than merely copied by hand.
+
+  `.github/scripts/release_notes.py` does the reading, and is tested against
+  this repository's real CHANGELOG: every released version must be describable,
+  a heading missing its date or theme fails, and a missing version is an error
+  rather than an untitled release. That check runs on every commit, not at tag
+  time — by tag time the tag is immutable and too late to fix.
+
 - **The SBOM could not be attached to a published release, and the job failed
   trying.** This repository enables release immutability, so a published
   release accepts no further assets — by hand or by workflow. The attach step

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ before 0.8.0 predate the convention and are left as they were released.
   a filename resolved once, in one step, so a tag push and a manual re-run
   cannot disagree about it.
 
+- **The SBOM could not be attached to a published release, and the job failed
+  trying.** This repository enables release immutability, so a published
+  release accepts no further assets — by hand or by workflow. The attach step
+  now warns and continues instead of failing: its own comment already said an
+  unattached SBOM "is not a failure", and the security-relevant output, the
+  attestation, is stored against the repository rather than as a release asset
+  and succeeds regardless. `SECURITY.md` and `RELEASE.md` both said to attach
+  the artifact when drafting the Release; both now say to do it **before
+  publishing**, which is the only window that exists.
+
+  `SECURITY.md` also records plainly that **v0.8.0 has no SBOM attached to its
+  Release**. The artifact and `make sbom` at the tag both still produce it, and
+  they are byte-identical, so nothing about verifying that release is lost.
+
 - **A failed SBOM job could not be retried.** The workflow ran only on a tag
   push, and re-running it from the tag re-runs the workflow file *as it was at
   that tag* — the same failure. With release immutability enabled the tag

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -122,6 +122,14 @@ The tag push triggers `.github/workflows/publish.yml`, which:
    attestations. **There are no stored credentials**; nothing to rotate or leak;
 3. generates and attests a CycloneDX SBOM, and uploads it as a workflow artifact.
 
+**If the SBOM job fails, publication has already happened.** It runs after the
+upload, so a failure there costs the attestation, not the release. Re-running
+the job from the tag re-runs the workflow file *as it was at that tag*, which
+will fail the same way. Fix the workflow on `main`, then use the manual
+trigger: Actions → Publish → Run workflow → enter the tag. Only the SBOM jobs
+run that way; publication is guarded off, since a version number is spent on
+first upload.
+
 Watch the run. If it fails before the upload step, delete the tag
 (`git push --delete origin vX.Y.Z && git tag -d vX.Y.Z`), fix, and re-tag.
 This works only while no Release has been published for that tag: with

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -151,6 +151,11 @@ In the web interface — Releases → Draft a new release — choose the existin
 tag, paste the title and body, and attach the `sbom` artifact downloaded
 from the workflow run. This is the ordinary path and needs no tooling.
 
+**Attach the SBOM before you press Publish.** With release immutability
+enabled, a published release accepts no further assets, and there is no
+way to add one afterwards — not by hand, and not by re-running the
+workflow. Only the title and notes stay editable.
+
 With the GitHub CLI, if you have it installed and authenticated:
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -137,41 +137,32 @@ release immutability enabled, publishing a Release freezes the tag, and
 the recovery becomes X.Y.Z+1 rather than a re-tag.
 **Once the upload succeeds, that version number is spent** — see step 6.
 
-## 5. Draft the GitHub Release
+## 5. Publish the GitHub Release
 
-**Publication has already happened by this point.** Pushing the tag is what
-uploads to PyPI; the GitHub Release is a separate, human-readable page. If
-you never create one, the package is still published. Nothing here is a
-prerequisite for anything.
+**The workflow has already drafted it.** After the tag push, the `release`
+job creates a **draft** Release with the SBOM attached, the title taken from
+the CHANGELOG heading and the body taken from that version's section. Nothing
+is retyped, so the Release and the changelog cannot disagree.
 
-The Release is normally written after the tag, so the SBOM job has usually
-finished and its artifact can be attached.
+All that is left is to read it and press **Publish**.
 
-In the web interface — Releases → Draft a new release — choose the existing
-tag, paste the title and body, and attach the `sbom` artifact downloaded
-from the workflow run. This is the ordinary path and needs no tooling.
+The draft matters. A draft accepts assets; a published release does not, once
+release immutability is enabled. Creating it with the SBOM already attached
+removes the step a human previously had to remember, and the only window in
+which it could be done.
 
-**Attach the SBOM before you press Publish.** With release immutability
-enabled, a published release accepts no further assets, and there is no
-way to add one afterwards — not by hand, and not by re-running the
-workflow. Only the title and notes stay editable.
+If a Release already exists for the tag when the job runs — because you
+drafted one by hand first — the job attaches the SBOM to it instead. If that
+release is already published and immutable, the job says so and does not fail:
+the attestation has already succeeded, and the SBOM stays downloadable as the
+run's `sbom` artifact.
 
-With the GitHub CLI, if you have it installed and authenticated:
+Should you need the notes outside the workflow:
 
 ```bash
-gh run download --repo varaprasadchilakanti/reveille --name sbom
-gh release create vX.Y.Z --title "vX.Y.Z — <headline>" --notes-file notes.md
-gh release upload vX.Y.Z reveille-*-sbom.cdx.json
+python3 .github/scripts/release_notes.py vX.Y.Z --title
+python3 .github/scripts/release_notes.py vX.Y.Z --body
 ```
-
-`gh` is a convenience, not a requirement, and it is not installed by
-default. The two paths produce the same Release.
-
-**The title is not invented here.** It is `vX.Y.Z` followed by the theme already
-written into the CHANGELOG heading in step 1 — e.g. *"v0.8.0 — Security
-Hardening, Apache-2.0, and a Rebuilt Report"*. Releases before 0.8.0 were
-titled the same way by hand; from 0.8.0 the changelog is the source. Body is the
-CHANGELOG section for that version, with the heading line dropped.
 
 ## 6. Verify from the published artefact
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,10 +75,10 @@ what an installation of it contains.
 The SBOM is produced by a job that is independent of publishing, so a
 failure to generate one cannot withhold a release. It is uploaded as the
 `sbom` artifact of the workflow run and attached to the GitHub Release.
-If the Release is drafted after the tag is pushed — the usual order — the
-artifact is attached by hand when it is drafted, and **before the Release
-is published**: this repository enables release immutability, and a
-published release accepts no further assets.
+The Release itself is drafted by that workflow, with the SBOM already
+attached, so there is no step in which a human has to remember to attach
+one. It is created as a draft: a draft accepts assets and a published
+release does not, because this repository enables release immutability.
 
 Where that was missed, the SBOM is still obtainable. It remains the
 `sbom` artifact of the workflow run, and it can be regenerated from the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,8 +75,17 @@ what an installation of it contains.
 The SBOM is produced by a job that is independent of publishing, so a
 failure to generate one cannot withhold a release. It is uploaded as the
 `sbom` artifact of the workflow run and attached to the GitHub Release.
-If the Release is drafted after the tag is pushed — the usual order —
-the artifact is attached by hand when it is drafted.
+If the Release is drafted after the tag is pushed — the usual order — the
+artifact is attached by hand when it is drafted, and **before the Release
+is published**: this repository enables release immutability, and a
+published release accepts no further assets.
+
+Where that was missed, the SBOM is still obtainable. It remains the
+`sbom` artifact of the workflow run, and it can be regenerated from the
+tag as below — the two are byte-identical, so neither is more
+authoritative than the other. **v0.8.0 has no SBOM attached to its
+Release**, because the attesting step failed on a glob it could not
+expand; the artifact and the regeneration path both work.
 
 The same file can be regenerated from a checkout at any tag:
 

--- a/tests/unit/test_dco_gate.py
+++ b/tests/unit/test_dco_gate.py
@@ -46,45 +46,69 @@ def _gate_script() -> str:
     return textwrap.dedent(match.group(1))
 
 
-def _run(tmp_path: Path, messages: list[str]) -> tuple[int, str]:
-    """Build a repository with these commit messages and run the gate.
+class _Repository:
+    """A throwaway repository the gate can be run against, repeatedly.
 
-    `{sha}` in a message is replaced with the full SHA of the commit
-    before it, so a remediation can name its target.
+    Commits are added one at a time and the gate re-run in place, so a
+    remediation can name a SHA that exists in the repository it is
+    checked against.
     """
 
-    def git(*args: str) -> str:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.name", "Test Person")
+        self._git("config", "user.email", "test@example.com")
+        (path / "seed").write_text("0", encoding="utf-8")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", f"seed{_SIGN_OFF}")
+        self.base = self._git("rev-parse", "HEAD")
+        self._files = 0
+
+    def _git(self, *args: str) -> str:
         return subprocess.run(
-            ["git", "-C", str(tmp_path), *args],
+            ["git", "-C", str(self.path), *args],
             capture_output=True,
             text=True,
             check=True,
         ).stdout.strip()
 
-    git("init", "-q", "-b", "main")
-    git("config", "user.name", "Test Person")
-    git("config", "user.email", "test@example.com")
-    (tmp_path / "seed").write_text("0", encoding="utf-8")
-    git("add", "-A")
-    git("commit", "-q", "-m", f"seed{_SIGN_OFF}")
-    base = git("rev-parse", "HEAD")
+    @property
+    def head(self) -> str:
+        """The current tip."""
+        return self._git("rev-parse", "HEAD")
 
-    previous = ""
-    for index, message in enumerate(messages):
-        (tmp_path / f"file{index}").write_text(str(index), encoding="utf-8")
-        git("add", "-A")
-        git("commit", "-q", "-m", message.format(sha=previous))
-        previous = git("rev-parse", "HEAD")
+    def commit(self, message: str) -> str:
+        """Add one commit and return its full SHA.
 
-    completed = subprocess.run(
-        [sys.executable, "-c", _gate_script()],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env={**os.environ, "BASE": base, "HEAD": previous},
-        timeout=60,
-    )
-    return completed.returncode, completed.stdout + completed.stderr
+        `{sha}` in the message is replaced with the current tip, so a
+        remediation can name the commit before it.
+        """
+        (self.path / f"file{self._files}").write_text(str(self._files), encoding="utf-8")
+        self._files += 1
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", message.format(sha=self.head))
+        return self.head
+
+    def check(self) -> tuple[int, str]:
+        """Run the shipped gate over base..HEAD."""
+        completed = subprocess.run(
+            [sys.executable, "-c", _gate_script()],
+            cwd=self.path,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BASE": self.base, "HEAD": self.head},
+            timeout=60,
+        )
+        return completed.returncode, completed.stdout + completed.stderr
+
+
+def _run(tmp_path: Path, messages: list[str]) -> tuple[int, str]:
+    """Build a repository with these commit messages and run the gate."""
+    repository = _Repository(tmp_path)
+    for message in messages:
+        repository.commit(message)
+    return repository.check()
 
 
 @pytest.mark.unit
@@ -136,29 +160,41 @@ class TestRemediation:
     def test_the_printed_template_satisfies_the_pattern_it_teaches(self, tmp_path: Path) -> None:
         """Follow the instructions literally; the gate must then pass.
 
-        This is the guard that closes the class of defect, rather than
-        the instance: whatever the failure message tells a contributor to
-        write, writing exactly that has to work.
-        """
-        first = tmp_path / "first"
-        first.mkdir()
-        _, output = _run(first, ["web ui commit"])
+        This closes the class of defect rather than an instance of it:
+        whatever the failure message tells a contributor to write,
+        writing exactly that has to work.
 
-        # The template is the indented block of the failure message.
+        It runs in **one** repository. An earlier version lifted the
+        template from a failure in one throwaway repository and applied
+        it in a second, where the SHA it named did not exist. That passed
+        locally and on three Python versions and failed on the fourth,
+        because two identical commits made in the same second hash
+        identically and in different seconds do not. A test that passes
+        for the wrong reason is worse than one that fails.
+        """
+        repository = _Repository(tmp_path)
+        repository.commit("web ui commit")
+
+        code, output = repository.check()
+        assert code == 1, "the unsigned commit should have failed the gate"
+
+        # The template is the indented block of the failure message, and
+        # it names this repository's own commit.
         template = "\n".join(
             line[4:] for line in output.splitlines() if line.startswith("    ")
         ).strip()
         assert "hereby add my" in template, f"no template in the output:\n{output}"
+        assert repository.head in template, "the template names some other commit"
 
-        second = tmp_path / "second"
-        second.mkdir()
-        message = template.replace("Your Name", "Test Person").replace(
-            "you@example.com", "test@example.com"
+        repository.commit(
+            template.replace("Your Name", "Test Person").replace(
+                "you@example.com", "test@example.com"
+            )
         )
-        code, second_output = _run(second, ["web ui commit", message])
+        code, after = repository.check()
         assert code == 0, (
             "copying the template the gate prints does not satisfy the gate:\n"
-            f"{message}\n---\n{second_output}"
+            f"{template}\n---\n{after}"
         )
 
     def test_an_unsigned_remediation_does_not_rescue_anything(self, tmp_path: Path) -> None:

--- a/tests/unit/test_release_notes.py
+++ b/tests/unit/test_release_notes.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2026 Vara Prasad Chilakanti
+# SPDX-License-Identifier: Apache-2.0
+
+"""The release notes are read from the CHANGELOG, not retyped.
+
+`.github/scripts/release_notes.py` turns a tag into the title and body
+the publish workflow gives to `gh release create`. It exists so the
+GitHub Release and the changelog cannot disagree, which is the reason
+the heading carries a theme at all.
+
+It is executed here against this repository's real CHANGELOG, so a
+heading that stops matching the convention fails the build rather than
+producing an untitled release at tag time -- by which point, with
+release immutability enabled, the notes are one of the few things still
+editable and the tag is not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _ROOT / ".github" / "scripts" / "release_notes.py"
+_CHANGELOG = _ROOT / "CHANGELOG.md"
+
+
+def _run(tag: str, flag: str, changelog: Path | None = None) -> tuple[int, str]:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(_SCRIPT),
+            tag,
+            flag,
+            "--changelog",
+            str(changelog or _CHANGELOG),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return completed.returncode, (completed.stdout + completed.stderr).strip()
+
+
+@pytest.mark.unit
+class TestAgainstThisRepositorysChangelog:
+    """The file that will actually be read at release time."""
+
+    def test_the_title_is_the_tag_and_the_heading_theme(self) -> None:
+        code, title = _run("v0.8.0", "--title")
+        assert code == 0, title
+        assert title == "v0.8.0 — Security Hardening, Apache-2.0, and a Rebuilt Report"
+
+    def test_the_title_matches_the_heading_in_the_file(self) -> None:
+        """Not a hardcoded string: read the heading and compare."""
+        heading = next(
+            line
+            for line in _CHANGELOG.read_text(encoding="utf-8").splitlines()
+            if line.startswith("## [0.8.0]")
+        )
+        theme = heading.split("—")[-1].strip()
+        _, title = _run("v0.8.0", "--title")
+        assert title.endswith(theme)
+
+    def test_the_body_is_that_version_and_stops_at_the_next(self) -> None:
+        code, body = _run("v0.8.0", "--body")
+        assert code == 0
+        assert "### Added" in body
+        assert "## [0.7.0]" not in body, "the body ran into the previous release"
+        assert "## [Unreleased]" not in body
+
+    def test_a_heading_without_a_theme_degrades_to_the_tag(self) -> None:
+        """Releases before the convention must stay describable."""
+        code, title = _run("v0.7.0", "--title")
+        assert code == 0
+        assert title == "v0.7.0"
+
+    def test_every_released_version_can_be_described(self) -> None:
+        """A version in the file that the script cannot read is a trap.
+
+        It would surface at tag time, when the tag is already immutable.
+        """
+        import re
+
+        versions = re.findall(
+            r"^## \[(\d+\.\d+\.\d+)\]", _CHANGELOG.read_text(encoding="utf-8"), re.MULTILINE
+        )
+        assert versions, "no released versions found in the CHANGELOG"
+        for version in versions:
+            code, output = _run(f"v{version}", "--title")
+            assert code == 0, f"v{version} cannot be described: {output}"
+
+
+@pytest.mark.unit
+class TestItFailsLoudlyRatherThanQuietly:
+    """An untitled release is worse than a failed job."""
+
+    def test_an_absent_version_is_an_error(self) -> None:
+        code, output = _run("v99.99.99", "--title")
+        assert code != 0
+        assert "no CHANGELOG heading" in output
+
+    def test_the_error_says_why_it_matters(self) -> None:
+        _, output = _run("v99.99.99", "--title")
+        assert "release notes are read from it" in output
+
+    def test_a_heading_with_no_date_is_not_matched(self, tmp_path: Path) -> None:
+        """The convention is version, date, theme. Two of three is not it."""
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("## [1.0.0] — Some Theme\n\nbody\n", encoding="utf-8")
+        code, _ = _run("v1.0.0", "--title", changelog)
+        assert code != 0


### PR DESCRIPTION
### Summary
Automates GitHub Release creation from the release workflow by generating a draft release with the SBOM artifact pre-attached. Extracts the release title and body directly from `CHANGELOG.md` heading conventions, replaces the previous glob targeting with explicit filenames, and gracefully handles immutable published releases without failing the pipeline.

### Changes
- **Release Automation**: Updated the release workflow to draft releases directly during pipeline execution with the SBOM artifact attached, avoiding the race condition with release immutability rules.
- **Changelog Extraction**: Added a tested parsing script to extract release notes and titles from `CHANGELOG.md` headings conforming to the `## [X.Y.Z] — DATE — Theme` convention, with fallback handling for legacy releases.
- **Asset Attachment & Guardrails**:
  - Replaced glob pattern in SBOM attestation with a deterministic target filename.
  - Added fallback handling: attach to existing release if present, draft if missing, and issue a warning rather than failing the run if an existing release is already published and immutable.
- **Testing**: Added 8 regression tests verifying changelog parsing, boundary stops, and missing-section handling across all historical releases.

### Verification
- `make ci` passing clean (778 passed, 0 failures).
- `actionlint` passing clean across modified workflows.
- Mutation tested against malformed changelog headings and version mismatches.
- All commits signed off (`Signed-off-by`).

### Contributor Agreement
- [x] I confirm that this contribution complies with the Developer Certificate of Origin (DCO)
  and is submitted under the Reveille-CLA-1.0 terms.