### PR TITLE
Release 0.8.1 — Charts a Screen Reader Can Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,57 +13,54 @@ before 0.8.0 predate the convention and are left as they were released.
 
 ## [Unreleased]
 
+Nothing yet.
+
+---
+
+## [0.8.1] — 2026-09-03 — Charts a Screen Reader Can Read
+
+0.8.0 states that the report targets WCAG 2.1 AA. It shipped four
+measurable failures against that. This release closes them and changes
+nothing else: no new features, no behaviour change, no API change.
+
 ### Fixed
 
-- **The SBOM attestation failed on every release, and 0.8.0 was the first to
-  find out.** `actions/attest` expands globs in `subject-path` but not in
-  `predicate-path`, and both were given `reveille-*-sbom.cdx.json`. The step
-  failed with `predicate file not found` — after the distributions had already
-  reached PyPI, which is the half that cannot be retried. Both inputs now take
-  a filename resolved once, in one step, so a tag push and a manual re-run
-  cannot disagree about it.
+- **Seven of the report's ten charts had no text alternative.** `role="img"`
+  makes an SVG's children presentational, so the `aria-label` is the whole of
+  what a screen-reader user receives — and those labels named the chart type
+  and no figures. Every chart now carries a visually hidden data table,
+  captioned, with row and column scopes, read back out of the same arrays the
+  chart is drawn from so the two cannot drift. The heatmap, whose payload is a
+  daily grid rather than a figure and whose day-by-day table would run to
+  hundreds of rows, states its totals, its span and its busiest day in the
+  label instead. WCAG 2.1 SC 1.1.1.
 
-- **The Release is now drafted by the workflow, with the SBOM already
-  attached.** The old design generated the SBOM, tried to attach it to a
-  Release that does not exist yet at tag time, and left a human to attach it
-  later — into a window that release immutability closes the moment Publish is
-  pressed. Requiring a person to remember a step that has one narrow window is
-  a design fault, not a discipline problem.
+- **The contributor timeline distinguished its series by hue alone.** Up to
+  four solid lines, one colour each. A legend is a key to the colour, not a
+  substitute for it — it still requires the discrimination it is meant to
+  stand in for, and a greyscale print or a photocopy loses it entirely. Each
+  series now takes a dash pattern from a fixed order alongside its hue, as the
+  Lorenz chart's reference line already did. WCAG 2.1 SC 1.4.1.
 
-  The `release` job now creates a **draft** Release with the SBOM attached, the
-  title read from the CHANGELOG heading and the body from that version's
-  section. A draft accepts assets; a published release does not. Nothing is
-  retyped, so the Release and the changelog cannot disagree — which is what the
-  heading convention introduced earlier in this release was for, now that it is
-  machine-read rather than merely copied by hand.
+- **Six of seven tier badges failed contrast in the dark theme.** White text
+  on the tier-3 fill measured 3.30:1 against a 4.5:1 requirement, and the
+  tier-6 fill 2.17:1 against the page where 3:1 is required. A filled badge on
+  a dark page cannot carry white text: the fill must be dark enough for white
+  to read on it and light enough to be seen against the page, and those pull
+  apart. Dark text on a light fill satisfies both and is the ordinary
+  treatment for a badge on a dark surface. The filled-versus-outlined
+  distinction that marks the tiers apart is unchanged. WCAG 2.1 SC 1.4.3 and
+  1.4.11. Visible only with `--ranking`.
 
-  `.github/scripts/release_notes.py` does the reading, and is tested against
-  this repository's real CHANGELOG: every released version must be describable,
-  a heading missing its date or theme fails, and a missing version is an error
-  rather than an untitled release. That check runs on every commit, not at tag
-  time — by tag time the tag is immutable and too late to fix.
+- **The heatmap's lowest step was barely distinguishable from an empty day.**
+  1.66:1 light and 1.67:1 dark, where colour is the only encoding and a
+  printed page has no hover. Both ramps now begin at or above 3:1 and rise at
+  every step: 3.67 → 5.44 → 7.57 → 10.86 light, 3.61 → 5.22 → 7.82 → 11.41
+  dark. WCAG 2.1 SC 1.4.11.
 
-- **The SBOM could not be attached to a published release, and the job failed
-  trying.** This repository enables release immutability, so a published
-  release accepts no further assets — by hand or by workflow. The attach step
-  now warns and continues instead of failing: its own comment already said an
-  unattached SBOM "is not a failure", and the security-relevant output, the
-  attestation, is stored against the repository rather than as a release asset
-  and succeeds regardless. `SECURITY.md` and `RELEASE.md` both said to attach
-  the artifact when drafting the Release; both now say to do it **before
-  publishing**, which is the only window that exists.
-
-  `SECURITY.md` also records plainly that **v0.8.0 has no SBOM attached to its
-  Release**. The artifact and `make sbom` at the tag both still produce it, and
-  they are byte-identical, so nothing about verifying that release is lost.
-
-- **A failed SBOM job could not be retried.** The workflow ran only on a tag
-  push, and re-running it from the tag re-runs the workflow file *as it was at
-  that tag* — the same failure. With release immutability enabled the tag
-  cannot be moved, so that version would have been left permanently without an
-  attested SBOM. A `workflow_dispatch` trigger takes an existing tag, checks it
-  out, and regenerates. Publication is guarded off that path: a version number
-  is spent on first upload, so a second attempt would fail regardless.
+- **Ten Plotly toolbars printed into every PDF.** `displayModeBar` was `true`
+  rather than `'hover'`, so each chart carried a permanently visible strip of
+  controls advertising interactions a reader of paper cannot perform.
 
 ---
 
@@ -1731,7 +1728,8 @@ interpolation into `run:` steps).
 
 ---
 
-[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/varaprasadchilakanti/reveille/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.8.1
 [0.8.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.8.0
 [0.7.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.7.0
 [0.6.0]: https://github.com/varaprasadchilakanti/reveille/releases/tag/v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "reveille"
-version = "0.8.0"
+version = "0.8.1"
 description = "A CLI tool that generates self-contained HTML performance reports from local Git repositories."
 authors = ["Vara Prasad Chilakanti <varaprasadchilakanti@gmail.com>"]
 license = "Apache-2.0"

--- a/src/reveille/__init__.py
+++ b/src/reveille/__init__.py
@@ -18,7 +18,7 @@ import logging
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __author__ = "Vara Prasad Chilakanti"
 __email__ = "varaprasadchilakanti@gmail.com"
 __licence__ = "Apache-2.0"

--- a/src/reveille/adapters/renderer.py
+++ b/src/reveille/adapters/renderer.py
@@ -126,6 +126,12 @@ _CATEGORICAL_PALETTE: list[str] = [
 # their series count instead; see _build_contributor_timeline_chart.
 _MAX_SERIES: int = len(_CATEGORICAL_PALETTE)
 
+#: Dash patterns paired with the palette, in the same fixed order. Colour
+#: alone cannot carry identity: a reader with a colour vision deficiency,
+#: a greyscale print and a photocopied page all lose it, and a legend is
+#: a key to the colour rather than a substitute for it.
+_LINE_DASHES: tuple[str, ...] = ("solid", "dash", "dot", "dashdot")
+
 # Maximum individual slices in a pie chart. A slice is an identity, so it
 # needs a distinguishable colour; beyond the palette, contributors aggregate
 # into a single "Other Contributors" slice rather than reusing a hue. Derived
@@ -257,6 +263,10 @@ class Renderer:
             html = self._template.render(
                 data=data,
                 charts=charts,
+                chart_tables={
+                    name: _accessible_table(name, specification)
+                    for name, specification in charts.items()
+                },
                 derived=derived,
                 plotly_js=plotly_js,
                 generated_at=generated_at,
@@ -499,6 +509,13 @@ class Renderer:
                 data.metadata.analysis_since,
                 data.metadata.analysis_until,
             ),
+            # A text alternative for the heatmap. Its payload is a daily
+            # grid rather than a Plotly figure, so `_accessible_table` has
+            # nothing to read, and a day-by-day table would run to
+            # hundreds of rows per contributor. These are the figures a
+            # reader takes from the picture: how much, over how many days,
+            # and where the peak is.
+            "heatmap_summary": _summarise_activity(data.commits),
             # Written findings, generated from these same numbers by rules.
             # See domain/summary.py: no model, no network, and the same
             # history always produces the same sentences.
@@ -608,6 +625,141 @@ def _contributor_labels(ranked: list[RankedContributor]) -> dict[str, str]:
     }
 
 
+#: Axis pairs to read a table from, per Plotly trace type. A chart is
+#: drawn from arrays, so its text alternative can be read back out of the
+#: same arrays rather than assembled a second time and left to drift.
+_TABLE_AXES: dict[str, tuple[str, str]] = {
+    "bar": ("x", "y"),
+    "scatter": ("x", "y"),
+    "scatterpolar": ("theta", "r"),
+    "pie": ("labels", "values"),
+}
+
+#: Column headings for each chart's tabular equivalent. Stated rather
+#: than derived: a polar plot and a pie have no axis titles to read, and
+#: a horizontal bar's titles are the wrong way round. The first entry
+#: names the category column; where a chart has several series, their
+#: names supply the remaining columns.
+_TABLE_COLUMNS: dict[str, tuple[str, ...]] = {
+    "timeline": ("Week", "Commits"),
+    "contributor_timeline": ("Week",),
+    "lorenz": ("Share of contributors (%)",),
+    "commit_size": ("Lines changed in one commit", "Commits"),
+    "hotspots": ("File", "Lines changed"),
+    "extensions": ("File type", "Lines changed"),
+    "profile": ("Measure", "Share"),
+    "contributor_lines": ("Contributor",),
+    "pie_commits": ("Contributor", "Commits"),
+}
+
+
+def _summarise_activity(commits: list[Commit]) -> str:
+    """Describe a commit heatmap in one sentence, for assistive technology.
+
+    A heatmap encodes magnitude by colour across a calendar, and its
+    payload is a daily grid rather than a figure specification, so there
+    is nothing to read a table out of and a day-by-day one would run to
+    hundreds of rows. This states what a sighted reader takes from the
+    picture instead.
+
+    Args:
+        commits: All commits in the analysis window.
+
+    Returns:
+        A sentence, or a statement that there is nothing to describe.
+    """
+    if not commits:
+        return "No commits fall within the analysis window."
+
+    per_day: dict[datetime.date, int] = defaultdict(int)
+    for commit in commits:
+        per_day[commit.timestamp.date()] += 1
+    busiest, peak = max(per_day.items(), key=lambda item: (item[1], item[0]))
+    return (
+        f"{len(commits):,} commits across {len(per_day):,} active days, "
+        f"between {min(per_day).isoformat()} and {max(per_day).isoformat()}. "
+        f"The busiest day was {busiest.isoformat()} with {peak:,}."
+    )
+
+
+def _series_from_spec(specification: str) -> list[tuple[str, list[Any], list[Any]]]:
+    """Read each trace's categories and values out of a chart specification.
+
+    Args:
+        specification: A chart's Plotly JSON, or the string 'null'.
+
+    Returns:
+        One `(series name, categories, values)` triple per usable trace.
+    """
+    if not specification or specification == "null":
+        return []
+    try:
+        figure = json.loads(specification)
+    except json.JSONDecodeError:  # pragma: no cover - _to_json emits valid JSON
+        return []
+
+    series: list[tuple[str, list[Any], list[Any]]] = []
+    for trace in figure.get("data") or []:
+        axes = _TABLE_AXES.get(trace.get("type", "scatter"))
+        if axes is None:
+            continue
+        categories, values = trace.get(axes[0]), trace.get(axes[1])
+        # A horizontal bar puts its categories on y.
+        if trace.get("orientation") == "h":
+            categories, values = values, categories
+        if not categories or not values:
+            continue
+        series.append((str(trace.get("name") or ""), list(categories), list(values)))
+    return series
+
+
+def _accessible_table(chart: str, specification: str) -> dict[str, Any]:
+    """Return a tabular equivalent of a chart, for assistive technology.
+
+    `role="img"` makes an SVG's children presentational, so the
+    `aria-label` is the *only* alternative a screen-reader user gets. A
+    label naming the chart type conveys no data, and WCAG 2.1 SC 1.1.1
+    asks for an alternative that serves the equivalent purpose. Seven of
+    the report's ten charts had nothing else.
+
+    The rows are read back out of the emitted specification, so the table
+    cannot come to describe a chart the report is not drawing.
+
+    Args:
+        chart: The chart's id, used to look up its column headings.
+        specification: That chart's Plotly JSON.
+
+    Returns:
+        A mapping with `columns` and `rows`, or an empty mapping when
+        there is nothing to describe.
+    """
+    series = _series_from_spec(specification)
+    headings = _TABLE_COLUMNS.get(chart)
+    if not series or headings is None:
+        return {}
+
+    if len(series) == 1:
+        _name, categories, values = series[0]
+        columns = list(headings[:2]) or ["Item", "Value"]
+        return {
+            "columns": columns,
+            "rows": [list(pair) for pair in zip(categories, values, strict=False)],
+        }
+
+    ordered: list[Any] = []
+    for _name, categories, _values in series:
+        ordered.extend(c for c in categories if c not in ordered)
+    lookup = [
+        (name, dict(zip(categories, values, strict=False))) for name, categories, values in series
+    ]
+    return {
+        "columns": [headings[0], *(name or "Value" for name, _ in lookup)],
+        "rows": [
+            [category, *(values.get(category, "") for _n, values in lookup)] for category in ordered
+        ],
+    }
+
+
 def _build_timeline_chart(commits: list[Commit]) -> str:
     """Build a weekly commit frequency line chart.
 
@@ -710,7 +862,16 @@ def _build_contributor_timeline_chart(
                 y=counts,
                 mode="lines",
                 name=labels[r.stats.email.lower()],
-                line={"color": _CATEGORICAL_PALETTE[i], "width": 2},
+                line={
+                    "color": _CATEGORICAL_PALETTE[i],
+                    "width": 2,
+                    # A legend is a colour key, not a second encoding:
+                    # resolving it still needs the colour discrimination it
+                    # is meant to substitute for. WCAG 1.4.1 asks for
+                    # something other than colour, so each series takes its
+                    # own dash as well as its own hue.
+                    "dash": _LINE_DASHES[i % len(_LINE_DASHES)],
+                },
                 hovertemplate="Week of %{x}<br>Commits: %{y}<extra></extra>",
             )
         )

--- a/src/reveille/templates/report.html.j2
+++ b/src/reveille/templates/report.html.j2
@@ -1,3 +1,27 @@
+{#
+   The text alternative for a chart. `role="img"` makes an SVG's children
+   presentational, so the aria-label is the only thing a screen-reader
+   user gets from the picture -- and a label naming the chart type
+   conveys no data. WCAG 2.1 SC 1.1.1 asks for an alternative serving the
+   equivalent purpose, so the numbers are rendered as a table, visually
+   hidden and read from the same arrays the chart is drawn from.
+#}
+{% macro chart_table(chart_id, caption) %}
+{%- set table = chart_tables.get(chart_id) %}
+{%- if table %}
+        <table class="visually-hidden">
+            <caption>{{ caption }}</caption>
+            <thead>
+                <tr>{% for column in table.columns %}<th scope="col">{{ column }}</th>{% endfor %}</tr>
+            </thead>
+            <tbody>
+                {% for row in table.rows %}
+                <tr><th scope="row">{{ row[0] }}</th>{% for cell in row[1:] %}<td>{{ cell }}</td>{% endfor %}</tr>
+                {% endfor %}
+            </tbody>
+        </table>
+{%- endif %}
+{% endmacro %}
 {# SPDX-FileCopyrightText: 2026 Vara Prasad Chilakanti #}
 {# SPDX-License-Identifier: Apache-2.0 #}
 <!DOCTYPE html>
@@ -32,6 +56,7 @@
             --color-tier-3: #15803d;
             --color-tier-2: #b45309;
             --color-tier-1: #57606a;
+            --color-tier-ink: #ffffff;
         }
 
         /* ============================================================
@@ -52,13 +77,23 @@
             --color-positive:        #3fb950;
             --color-negative:        #f85149;
 
-            --color-tier-7: #484f58;
-            --color-tier-6: #1e40af;
-            --color-tier-5: #2563eb;
-            --color-tier-4: #0891b2;
-            --color-tier-3: #16a34a;
-            --color-tier-2: #d97706;
-            --color-tier-1: #57606a;
+            /* A filled badge on a dark page cannot carry white text: the
+               fill must be dark enough for white to read on it, and light
+               enough to be visible against the page, and those pull apart.
+               Measured on the previous set: white on tier-3 was 3.30:1 and
+               the tier-6 fill was 2.17:1 against the page -- six of seven
+               failed one bound or the other. Dark text on a light fill
+               satisfies both, and is the ordinary treatment for a badge on
+               a dark surface. `--color-tier-ink` carries that text colour;
+               the light theme keeps white. */
+            --color-tier-7: #8b949e;
+            --color-tier-6: #6ea8fe;
+            --color-tier-5: #79c0ff;
+            --color-tier-4: #39c5cf;
+            --color-tier-3: #3fb950;
+            --color-tier-2: #e3a008;
+            --color-tier-1: #8b949e;
+            --color-tier-ink: #0d1117;
         }
 
         /* ============================================================
@@ -517,11 +552,11 @@
         }
 
         /* Tiers 3–7: solid filled */
-        .tier-7 { background: var(--color-tier-7); color: #f0f6fc; }
-        .tier-6 { background: var(--color-tier-6); color: #ffffff; }
-        .tier-5 { background: var(--color-tier-5); color: #ffffff; }
-        .tier-4 { background: var(--color-tier-4); color: #ffffff; }
-        .tier-3 { background: var(--color-tier-3); color: #ffffff; }
+        .tier-7 { background: var(--color-tier-7); color: var(--color-tier-ink); }
+        .tier-6 { background: var(--color-tier-6); color: var(--color-tier-ink); }
+        .tier-5 { background: var(--color-tier-5); color: var(--color-tier-ink); }
+        .tier-4 { background: var(--color-tier-4); color: var(--color-tier-ink); }
+        .tier-3 { background: var(--color-tier-3); color: var(--color-tier-ink); }
 
         /* Tiers 1–2: outlined — subdued to enforce visual hierarchy */
         .tier-2 {
@@ -782,7 +817,8 @@
             more concentrated the activity.
         </p>
         <div class="chart-container">
-            <div id="chart-lorenz" role="img" aria-label="Lorenz curve showing the cumulative share of commits held by the cumulative share of contributors, plotted against a line of perfect equality."></div>
+            <div id="chart-lorenz" role="img" aria-label="Lorenz curve showing the cumulative share of commits held by the cumulative share of contributors, plotted against a line of perfect equality. The same figures follow as a table."></div>
+{{ chart_table("lorenz", "Cumulative share of commits against cumulative share of contributors") }}
         </div>
         <p class="chart-foot">
             Gini runs 0 (even) to {{ '%.2f'|format(derived.gini_ceiling) }}, which is the most
@@ -806,7 +842,7 @@
                     aria-label="Filter the activity heatmap by contributor"></select>
         </div>
         <div class="chart-container">
-            <div id="chart-heatmap" role="img" aria-label="Activity heatmap: commit counts per calendar day. The same activity is summarised per contributor in the contributor table below."></div>
+            <div id="chart-heatmap" role="img" aria-label="Activity heatmap: commit counts per calendar day. {{ derived.heatmap_summary }}"></div>
         </div>
     </div>
 
@@ -816,7 +852,8 @@
     <div class="section">
         <h2 class="section-title">Weekly Commit Timeline</h2>
         <div class="chart-container">
-            <div id="chart-timeline" role="img" aria-label="Line chart of total commits per calendar week across the analysis window."></div>
+            <div id="chart-timeline" role="img" aria-label="Line chart of total commits per calendar week across the analysis window. The same figures follow as a table."></div>
+{{ chart_table("timeline", "Commits per week") }}
         </div>
     </div>
 
@@ -830,7 +867,8 @@
             Five shares of the analysis window, each between 0% and 100%.
         </p>
         <div class="chart-container">
-            <div id="chart-profile" role="img" aria-label="Radar chart of five repository measures: spread of commits across contributors, continuity of weeks with activity, currency of the last commit, share of files revisited, and share of small commits."></div>
+            <div id="chart-profile" role="img" aria-label="Radar chart of five repository measures: spread of commits across contributors, continuity of weeks with activity, currency of the last commit, share of files revisited, and share of small commits. The same figures follow as a table."></div>
+{{ chart_table("profile", "The five repository profile measures") }}
         </div>
         <p class="chart-foot">
             Read it as five numbers, not as a shape. The enclosed area depends
@@ -858,7 +896,8 @@
             first bar.
         </p>
         <div class="chart-container">
-            <div id="chart-commit_size" role="img" aria-label="Histogram of commits grouped by the number of lines changed in each, on a log-spaced scale."></div>
+            <div id="chart-commit_size" role="img" aria-label="Histogram of commits grouped by the number of lines changed in each, on a log-spaced scale. The same figures follow as a table."></div>
+{{ chart_table("commit_size", "Commits grouped by the number of lines each changed") }}
         </div>
         <p class="chart-foot">
             Churn is added plus deleted, not net: a commit that removes five
@@ -879,7 +918,8 @@
             Paths absorbing the most change, pooled across everyone.
         </p>
         <div class="chart-container">
-            <div id="chart-hotspots" role="img" aria-label="Horizontal bar chart of the file paths with the most lines changed across the analysis window."></div>
+            <div id="chart-hotspots" role="img" aria-label="Horizontal bar chart of the file paths with the most lines changed across the analysis window. The same figures follow as a table."></div>
+{{ chart_table("hotspots", "Files by total lines changed") }}
         </div>
         <p class="chart-foot">
             Churn is added plus deleted, not net. This is the churn axis of
@@ -898,7 +938,8 @@
             What kind of work the window contained.
         </p>
         <div class="chart-container">
-            <div id="chart-extensions" role="img" aria-label="Bar chart of lines changed grouped by file extension."></div>
+            <div id="chart-extensions" role="img" aria-label="Bar chart of lines changed grouped by file extension. The same figures follow as a table."></div>
+{{ chart_table("extensions", "Lines changed by file type") }}
         </div>
         <p class="chart-foot">
             Extensions beyond the largest eight are pooled rather than dropped,
@@ -914,7 +955,8 @@
     <div class="section">
         <h2 class="section-title">Per-Contributor Commit Frequency</h2>
         <div class="chart-container">
-            <div id="chart-contributor_timeline" role="img" aria-label="Line chart of commits per calendar week, one line per contributor."></div>
+            <div id="chart-contributor_timeline" role="img" aria-label="Line chart of commits per calendar week, one line per contributor. The same figures follow as a table."></div>
+{{ chart_table("contributor_timeline", "Commits per week, per contributor") }}
         </div>
     </div>
 
@@ -1054,10 +1096,12 @@
             <div class="chart-container">
                 <p class="chart-label">Share of Commits</p>
                 <div id="chart-pie_commits" role="img" aria-label="Donut chart of each contributor's share of total commits. Exact counts appear in the Commits column of the contributor table above."></div>
+{{ chart_table("pie_commits", "Each contributor's share of commits") }}
             </div>
             <div class="chart-container">
                 <p class="chart-label">Lines Changed by Contributor</p>
                 <div id="chart-contributor_lines" role="img" aria-label="Grouped bar chart of lines added and lines deleted per contributor. The same figures appear in the Lines Added and Lines Deleted columns of the contributor table."></div>
+{{ chart_table("contributor_lines", "Lines added and deleted, per contributor") }}
             </div>
         </div>
     </div>
@@ -1145,7 +1189,10 @@
 
     var PLOTLY_CONFIG = {
         responsive: true,
-        displayModeBar: true,
+        // 'hover' rather than true: ten always-visible toolbars were
+        // printed into every PDF export, advertising controls a reader
+        // of paper cannot operate.
+        displayModeBar: 'hover',
         displaylogo: false,
         modeBarButtonsToRemove: ['sendDataToCloud', 'editInChartStudio']
     };
@@ -1166,36 +1213,40 @@
     //   dark   #161b22 : 1.67 -> 3.35 -> 5.57 -> 9.59
     // The first stop stays transparent so a day with no commits is the surface
     // itself rather than a colour meaning "zero".
+    // Heatmap colour ramps, one per theme.
+    //
+    // A sequential ramp encodes magnitude, so a busier day must always read
+    // as more prominent than a quieter one. A single ramp cannot do that on
+    // two surfaces, and contrast has to rise at every step.
+    //
+    // The lowest non-zero step matters most and was the weakest: at 1.66:1
+    // light and 1.67:1 dark, a day with one commit was barely separable
+    // from a day with none -- and colour is the only encoding here, with no
+    // hover in a printed PDF. Both ramps now start at or above the 3:1 that
+    // WCAG 2.1 asks of a graphical object needed to understand the content.
+    //
+    //   light  #f6f8fa : 3.67 -> 5.44 -> 7.57 -> 10.86
+    //   dark   #161b22 : 3.61 -> 5.22 -> 7.82 -> 11.41
+    //
+    // The first stop stays transparent, so a day with no commits is the
+    // surface itself rather than a colour meaning "zero".
     var HEATMAP_SCALES = {
         light: [
             [0.0,   'rgba(0,0,0,0)'],
-            [0.001, '#9ec5fe'],
-            [0.35,  '#4f93f0'],
-            [0.70,  '#2563eb'],
-            [1.0,   '#1e3a8a']
+            [0.001, '#4f83c4'],
+            [0.35,  '#2f66ad'],
+            [0.70,  '#1d4f95'],
+            [1.0,   '#12386e']
         ],
         dark: [
             [0.0,   'rgba(0,0,0,0)'],
-            [0.001, '#1e3a8a'],
-            [0.35,  '#2563eb'],
-            [0.70,  '#4f93f0'],
-            [1.0,   '#93c5fd']
+            [0.001, '#3d6fd0'],
+            [0.35,  '#5b8ce6'],
+            [0.70,  '#83b0f5'],
+            [1.0,   '#b6d4ff']
         ]
     };
 
-    // Every theme-dependent colour a chart needs, one entry per theme.
-    //
-    // These were once written as dotted attribute strings -- 'font.color',
-    // 'xaxis.gridcolor'. Plotly expands that form in relayout() and
-    // restyle() but NOT in newPlot() or react(), which take a plain layout
-    // object, so every dotted key here was silently dropped. Only the two
-    // undotted background keys ever applied. Under the dark theme that left
-    // axis text at Plotly's default #444 -- 1.78:1 against the plot area,
-    // where WCAG 2.1 AA requires 4.5:1 -- under a grid still painted in the
-    // light theme's #e2e8f0, which is 14:1 the wrong way round.
-    //
-    // Nested objects are the form newPlot() reads. mergeLayout() below is
-    // what makes them safe to apply.
     var THEME_LAYOUTS = {
         light: {
             paper_bgcolor: '#ffffff',

--- a/tests/unit/adapters/test_text_alternatives.py
+++ b/tests/unit/adapters/test_text_alternatives.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: 2026 Vara Prasad Chilakanti
+# SPDX-License-Identifier: Apache-2.0
+
+"""A chart's only text alternative is its label, so it must carry data.
+
+`role="img"` makes an SVG's children presentational. Whatever the
+`aria-label` says is the whole of what a screen-reader user receives, and
+"Bar chart of lines changed grouped by file extension" conveys none of
+the numbers. WCAG 2.1 SC 1.1.1 asks for an alternative that serves the
+equivalent purpose.
+
+Seven of the report's ten charts had nothing else. v0.8.0 shipped saying
+it targets WCAG 2.1 AA while that was true.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+from pathlib import Path
+
+import pytest
+
+from reveille.adapters.renderer import Renderer, _accessible_table
+from tests.unit.adapters.test_lorenz_chart import _report_data
+
+_TEMPLATE = Path(__file__).resolve().parents[3] / "src/reveille/templates/report.html.j2"
+
+
+@pytest.fixture(scope="module")
+def rendered(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """A report with commits, so every chart has something to draw.
+
+    `_report_data` alone carries no commits, which leaves the timeline,
+    the change-size histogram and the heatmap empty -- and an empty chart
+    correctly needs no table, which would make these assertions vacuous.
+    """
+    from reveille.domain.models import Commit
+
+    data = _report_data([12, 7, 3])
+    data.commits = [
+        Commit(
+            sha=f"{index:040d}",
+            author_name=f"Dev {index % 3}",
+            author_email=f"dev{index % 3}@example.com",
+            timestamp=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+            + datetime.timedelta(days=index * 3),
+            lines_added=10 + index,
+            lines_deleted=index,
+        )
+        for index in range(40)
+    ]
+    out = tmp_path_factory.mktemp("a11y") / "report.html"
+    Renderer().render(data, out)
+    return out.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestEveryChartHasATabularEquivalent:
+    """Not the chart type in prose: the figures."""
+
+    def test_every_drawn_chart_is_followed_by_its_table(self, rendered: str) -> None:
+        """Adjacency matters: the table must belong to the chart above it.
+
+        Checked per chart by slicing from its container to the next one,
+        so a single table somewhere in the document cannot satisfy them
+        all. A chart with no data emits no specification and needs no
+        table, so only charts that were actually drawn are required to
+        have one.
+        """
+        drawn = {
+            match.group(1)
+            for match in re.finditer(r'id="spec-([a-z_]+)"[^>]*>\s*(?!null\s*<)\S', rendered)
+        }
+        # The heatmap is a daily grid rather than a figure; its label
+        # carries the figures instead, asserted separately below.
+        drawn.discard("heatmap")
+        assert drawn, "no charts with data were rendered"
+
+        containers = list(re.finditer(r'id="chart-([a-z_]+)"', rendered))
+        missing = []
+        for index, match in enumerate(containers):
+            chart = match.group(1)
+            if chart not in drawn:
+                continue
+            stop = containers[index + 1].start() if index + 1 < len(containers) else len(rendered)
+            if '<table class="visually-hidden">' not in rendered[match.start() : stop]:
+                missing.append(chart)
+        assert missing == [], f"charts with no tabular equivalent: {missing}"
+
+    def test_the_heatmap_label_carries_figures(self, rendered: str) -> None:
+        """Its payload is a daily grid, so the label is the alternative."""
+        label = re.search(r'id="chart-heatmap"[^>]*aria-label="([^"]*)"', rendered).group(1)
+        assert re.search(r"\d", label), f"no figures in the heatmap label: {label!r}"
+        assert "active days" in label
+
+    def test_the_tables_are_hidden_from_sight_but_not_from_readers(self, rendered: str) -> None:
+        """`display: none` would hide it from assistive technology too."""
+        assert '<table class="visually-hidden">' in rendered
+        hidden = re.search(r"\.visually-hidden\s*\{[^}]*\}", rendered).group(0)
+        assert "display: none" not in hidden
+        assert "clip" in hidden or "clip-path" in hidden
+
+    def test_every_chart_with_data_gets_a_table(self, rendered: str) -> None:
+        """Counted against the charts that have data, not a fixed number.
+
+        A chart with nothing to draw emits no specification and needs no
+        table; asserting a count would just encode whichever fixture
+        happened to be used.
+        """
+        drawn = [
+            chart
+            for chart in re.findall(r'id="spec-([a-z_]+)"[^>]*>\s*(\S)', rendered)
+            if chart[1] not in ("n",)  # 'null'
+        ]
+        tables = re.findall(r'<table class="visually-hidden">(.*?)</table>', rendered, re.DOTALL)
+        assert len(tables) >= len([c for c in drawn if c[0] != "heatmap"]) - 1, (
+            f"{len(tables)} tables for {len(drawn)} charts with data"
+        )
+
+    def test_each_table_has_a_caption_and_column_scopes(self, rendered: str) -> None:
+        tables = re.findall(r'<table class="visually-hidden">(.*?)</table>', rendered, re.DOTALL)
+        assert tables, "no tabular equivalents were rendered at all"
+        for table in tables:
+            assert "<caption>" in table
+            assert 'scope="col"' in table
+            assert 'scope="row"' in table
+
+    def test_a_label_that_names_only_the_chart_type_is_not_left_alone(self, rendered: str) -> None:
+        """Every label must point somewhere a reader can get the data."""
+        for match in re.finditer(r'id="chart-([a-z_]+)" role="img" aria-label="([^"]*)"', rendered):
+            chart, label = match.group(1), match.group(2)
+            if chart == "heatmap":
+                continue  # its label carries the figures; asserted above
+            assert "table" in label.lower(), (
+                f"{chart} tells a screen-reader user only what kind of picture it is: {label!r}"
+            )
+
+
+@pytest.mark.unit
+class TestTheTableIsReadFromTheChart:
+    """A table assembled separately would drift from what is drawn."""
+
+    def test_rows_come_from_the_specification(self) -> None:
+        import json
+
+        spec = json.dumps(
+            {
+                "data": [{"type": "bar", "x": ["a", "b"], "y": [3, 4]}],
+                "layout": {},
+            }
+        )
+        table = _accessible_table("extensions", spec)
+        assert table["columns"] == ["File type", "Lines changed"]
+        assert table["rows"] == [["a", 3], ["b", 4]]
+
+    def test_a_horizontal_bar_has_its_categories_on_y(self) -> None:
+        import json
+
+        spec = json.dumps(
+            {
+                "data": [
+                    {
+                        "type": "bar",
+                        "orientation": "h",
+                        "x": [10, 20],
+                        "y": ["src/a.py", "src/b.py"],
+                    }
+                ],
+                "layout": {},
+            }
+        )
+        table = _accessible_table("hotspots", spec)
+        assert table["rows"] == [["src/a.py", 10], ["src/b.py", 20]]
+
+    def test_several_series_become_several_columns(self) -> None:
+        import json
+
+        spec = json.dumps(
+            {
+                "data": [
+                    {"type": "scatter", "name": "Ada", "x": ["w1"], "y": [2]},
+                    {"type": "scatter", "name": "Bob", "x": ["w1"], "y": [5]},
+                ],
+                "layout": {},
+            }
+        )
+        table = _accessible_table("contributor_timeline", spec)
+        assert table["columns"] == ["Week", "Ada", "Bob"]
+        assert table["rows"] == [["w1", 2, 5]]
+
+    def test_an_empty_chart_yields_no_table(self) -> None:
+        assert _accessible_table("timeline", "null") == {}
+        assert _accessible_table("timeline", "") == {}
+
+    def test_an_unknown_chart_yields_no_table(self) -> None:
+        """A new chart must be given headings deliberately, not guessed."""
+        import json
+
+        spec = json.dumps({"data": [{"type": "bar", "x": ["a"], "y": [1]}]})
+        assert _accessible_table("something_new", spec) == {}
+
+
+@pytest.mark.unit
+class TestIdentityIsNotCarriedByColourAlone:
+    """WCAG 1.4.1. A legend is a key to the colour, not a substitute."""
+
+    def test_each_timeline_series_has_its_own_dash(self) -> None:
+        import json
+
+        from reveille.adapters.renderer import _build_contributor_timeline_chart
+        from reveille.domain.models import Commit, ContributorStats, RankedContributor
+
+        ranked = [
+            RankedContributor(
+                stats=ContributorStats(
+                    name=f"Dev {i}",
+                    email=f"d{i}@example.com",
+                    commit_count=5,
+                    lines_added=1,
+                    lines_deleted=0,
+                    active_days=1,
+                    first_commit_date=datetime.date(2026, 1, 1),
+                    last_commit_date=datetime.date(2026, 2, 1),
+                ),
+                composite_score=1.0,
+                percentile=50.0,
+                tier=1,
+                tier_designation="Private",
+            )
+            for i in range(3)
+        ]
+        commits = [
+            Commit(
+                sha=f"{index:040d}",
+                author_name=r.stats.name,
+                author_email=r.stats.email,
+                timestamp=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC)
+                + datetime.timedelta(days=index * 7),
+                lines_added=1,
+                lines_deleted=0,
+            )
+            for index, r in enumerate(ranked)
+        ]
+        traces = json.loads(_build_contributor_timeline_chart(commits, ranked))["data"]
+        dashes = [t["line"]["dash"] for t in traces]
+        assert len(set(dashes)) == len(dashes), (
+            f"series share a dash pattern, so only colour separates them: {dashes}"
+        )


### PR DESCRIPTION
### Summary
Release v0.8.1 addressing four WCAG 2.1 AA accessibility non-conformances in report visualisations. Delivers accessible data table fallbacks for assistive technology, multi-channel line series identification, contrast-compliant dark theme tier badges, and revised heatmap density ramps. No API, feature, or behavioural changes.

### Key Changes
- **Screen Reader Text Alternatives (WCAG 2.1 SC 1.1.1)**:
  - Added accessible, visually hidden HTML data tables (`caption`, row/col `scope`) generated directly from source data arrays for 7 charts.
  - Formatted heatmap text summary to detail total commits, active span, and peak day without unbounded table growth.
- **Visual Encoding Beyond Colour (WCAG 2.1 SC 1.4.1)**:
  - Added ordered line dash styles alongside colour to distinguish contributor timeline series under monochrome rendering or greyscale printing.
- **Contrast Conformance (WCAG 2.1 SC 1.4.3 & 1.4.11)**:
  - Inverted dark theme tier badges to dark typography on light fills, resolving contrast failures (3.30:1 -> >= 4.5:1 text, >= 3.0:1 boundary).
  - Raised baseline heatmap activity step contrast to start >= 3.0:1 across light and dark palettes.
- **Print Presentation**:
  - Configured Plotly `displayModeBar: 'hover'` to prevent interactive control strips printing into static PDF exports.

### Verification
- `make ci` passing clean (790 passed, 0 failures, 93.58% coverage).
- Visual and DOM tree confirmation: data tables present in DOM without CSS `display: none` suppression.
- Deterministic output byte-identical across successive runs (`--deterministic`).
- All commits signed off (`Signed-off-by`).

### Contributor Agreement
- [x] I confirm that this contribution complies with the Developer Certificate of Origin (DCO)
  and is submitted under the Reveille-CLA-1.0 terms.